### PR TITLE
refactor: clean up the initialization procedure

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,332 +11,332 @@ function instance(system, id, config) {
 
 	instance_skel.apply(this, arguments);
 
-    self.actions();
-    
+	self.actions();
+
 	return self;
 };
 
 instance.prototype.updateConfig = function(config){
-    var self = this;
-    self.config = config;
-    console.log("Update config YT_module")
-    self.destroy();
-    self.init();
+	var self = this;
+	self.config = config;
+	console.log("Update config YT_module")
+	self.destroy();
+	self.init();
 }
 
 instance.prototype.init = function(){
-    console.log("Init YT_module")
-    var self = this;
-    var yt_dir_path = self.config.path_to_yt_directory;
-    var secrets_file_path = yt_dir_path + "client-secret.json";
-    var token_path = yt_dir_path + "token.json";
+	console.log("Init YT_module")
+	var self = this;
+	var yt_dir_path = self.config.path_to_yt_directory;
+	var secrets_file_path = yt_dir_path + "client-secret.json";
+	var token_path = yt_dir_path + "token.json";
 
-    var scopes = ["https://www.googleapis.com/auth/youtube.force-ssl"];
+	var scopes = ["https://www.googleapis.com/auth/youtube.force-ssl"];
 
-    if (yt_dir_path) {
-        if (fs.lstatSync(secrets_file_path).isFile()) {
-            var config_file = fs.readFileSync(secrets_file_path);
-            var config_json = JSON.parse(config_file);
-            var client_id = config_json["web"]["client_id"];
-            var client_secret = config_json["web"]["client_secret"];
-            console.log("client_seceret: " + client_secret);
-            var redirect_url = config_json["web"]["redirect_uris"][0];
+	if (yt_dir_path) {
+		if (fs.lstatSync(secrets_file_path).isFile()) {
+			var config_file = fs.readFileSync(secrets_file_path);
+			var config_json = JSON.parse(config_file);
+			var client_id = config_json["web"]["client_id"];
+			var client_secret = config_json["web"]["client_secret"];
+			console.log("client_seceret: " + client_secret);
+			var redirect_url = config_json["web"]["redirect_uris"][0];
 
-            self.yt_api_handler = new Youtube_api_handler(client_id, client_secret, redirect_url, scopes, token_path);
-            if (fs.existsSync(token_path)){
-                if (fs.lstatSync(token_path).isFile()){
-                    console.log("Token file (token.json) is provided");
-            
-                    fs.readFile(token_path, (error, token) => {
-                        if (error) {
-                            let promise = self.yt_api_handler.oauth_login()
-                            promise.then(acces_credentials => {
-                                self.yt_api_handler.oauth2client.credentials = acces_credentials;
-                                self.yt_api_handler.create_yt_service();
-                                let get_broadcasts = self.yt_api_handler.get_all_broadcasts();
-                                get_broadcasts.then(streams_dict => {
-                                    self.yt_api_handler.streams_dict = streams_dict;
-                                    console.log(self.yt_api_handler.streams_dict);
-                                    self.actions();
-                                });
-                                get_broadcasts.catch(console.error); 
-                            });
-                            promise.catch(console.error);    
-                        } else {
-                            self.yt_api_handler.oauth2client.credentials = JSON.parse(token);
-                            self.yt_api_handler.create_yt_service();
-                            let get_broadcasts = self.yt_api_handler.get_all_broadcasts();
-                            get_broadcasts.then(streams_dict => {
-                                self.yt_api_handler.streams_dict = streams_dict;
-                                console.log(self.yt_api_handler.streams_dict);
-                                self.actions();
-                            });
-                            get_broadcasts.catch(console.error); 
-                        }
-                    });
-                } else {
-                    console.log("Token file (token.json) cannot be used, you need to sign in")
-                    let promise = self.yt_api_handler.oauth_login()
-                    promise.then(acces_credentials => {
-                        self.yt_api_handler.oauth2client.credentials = acces_credentials;
-                        self.yt_api_handler.create_yt_service();
-                        let get_broadcasts = self.yt_api_handler.get_all_broadcasts();
-                        get_broadcasts.then(streams_dict => {
-                            self.yt_api_handler.streams_dict = streams_dict;
-                            console.log(self.yt_api_handler.streams_dict);
-                            self.actions();
-                        });
-                        get_broadcasts.catch(console.error); 
-                    });
-                    promise.catch(console.error); 
-                }
-            } else {
-                console.log("Token file (token.json) does not exist, you need to sign in.")
-                let promise = self.yt_api_handler.oauth_login()
-                    promise.then(acces_credentials => {
-                        self.yt_api_handler.oauth2client.credentials = acces_credentials;
-                        self.yt_api_handler.create_yt_service();
-                        let get_broadcasts = self.yt_api_handler.get_all_broadcasts();
-                        get_broadcasts.then(streams_dict => {
-                            self.yt_api_handler.streams_dict = streams_dict;
-                            console.log(self.yt_api_handler.streams_dict);
-                            self.actions();
-                        });
-                        get_broadcasts.catch(console.error); 
-                    });
-                    promise.catch(console.error); 
-            }
-            
-        }
+			self.yt_api_handler = new Youtube_api_handler(client_id, client_secret, redirect_url, scopes, token_path);
+			if (fs.existsSync(token_path)){
+				if (fs.lstatSync(token_path).isFile()){
+					console.log("Token file (token.json) is provided");
 
-    } else {
-        console.error("Path to YouTube operating directory is not provided");
-    }
+					fs.readFile(token_path, (error, token) => {
+						if (error) {
+							let promise = self.yt_api_handler.oauth_login()
+							promise.then(acces_credentials => {
+								self.yt_api_handler.oauth2client.credentials = acces_credentials;
+								self.yt_api_handler.create_yt_service();
+								let get_broadcasts = self.yt_api_handler.get_all_broadcasts();
+								get_broadcasts.then(streams_dict => {
+									self.yt_api_handler.streams_dict = streams_dict;
+									console.log(self.yt_api_handler.streams_dict);
+									self.actions();
+								});
+								get_broadcasts.catch(console.error);
+							});
+							promise.catch(console.error);
+						} else {
+							self.yt_api_handler.oauth2client.credentials = JSON.parse(token);
+							self.yt_api_handler.create_yt_service();
+							let get_broadcasts = self.yt_api_handler.get_all_broadcasts();
+							get_broadcasts.then(streams_dict => {
+								self.yt_api_handler.streams_dict = streams_dict;
+								console.log(self.yt_api_handler.streams_dict);
+								self.actions();
+							});
+							get_broadcasts.catch(console.error);
+						}
+					});
+				} else {
+					console.log("Token file (token.json) cannot be used, you need to sign in")
+					let promise = self.yt_api_handler.oauth_login()
+					promise.then(acces_credentials => {
+						self.yt_api_handler.oauth2client.credentials = acces_credentials;
+						self.yt_api_handler.create_yt_service();
+						let get_broadcasts = self.yt_api_handler.get_all_broadcasts();
+						get_broadcasts.then(streams_dict => {
+							self.yt_api_handler.streams_dict = streams_dict;
+							console.log(self.yt_api_handler.streams_dict);
+							self.actions();
+						});
+						get_broadcasts.catch(console.error);
+					});
+					promise.catch(console.error);
+				}
+			} else {
+				console.log("Token file (token.json) does not exist, you need to sign in.")
+				let promise = self.yt_api_handler.oauth_login()
+					promise.then(acces_credentials => {
+						self.yt_api_handler.oauth2client.credentials = acces_credentials;
+						self.yt_api_handler.create_yt_service();
+						let get_broadcasts = self.yt_api_handler.get_all_broadcasts();
+						get_broadcasts.then(streams_dict => {
+							self.yt_api_handler.streams_dict = streams_dict;
+							console.log(self.yt_api_handler.streams_dict);
+							self.actions();
+						});
+						get_broadcasts.catch(console.error);
+					});
+					promise.catch(console.error);
+			}
+
+		}
+
+	} else {
+		console.error("Path to YouTube operating directory is not provided");
+	}
 };
 
 instance.prototype.destroy = function(){
-    var self = this;
-    self.stream_to_start_list = [];
-    self.stream_to_stop_list = [];
+	var self = this;
+	self.stream_to_start_list = [];
+	self.stream_to_stop_list = [];
 };
 
 instance.prototype.config_fields = function(){
-    var self = this;
-    return [
-        {
-            type: 'text',
-            id: 'info',
-            width: 12,
-            label: 'Information',
-            value: "The path to the folder should contain / or \\ at the end. (Depends on your system -> Unix: / ; Win: \\)"
-        },
-        {
-            type: "textinput",
-            id: "path_to_yt_directory",
-            label: "Path to YouTube working directory:",
-            width: 4,
-            required: true
-        }
-    ]
+	var self = this;
+	return [
+		{
+			type: 'text',
+			id: 'info',
+			width: 12,
+			label: 'Information',
+			value: "The path to the folder should contain / or \\ at the end. (Depends on your system -> Unix: / ; Win: \\)"
+		},
+		{
+			type: "textinput",
+			id: "path_to_yt_directory",
+			label: "Path to YouTube working directory:",
+			width: 4,
+			required: true
+		}
+	]
 };
 
 instance.prototype.actions = function(system){
-    var self = this;
+	var self = this;
 
-    self.streams_list_to_display = [];
+	self.streams_list_to_display = [];
 
-    if (self.yt_api_handler !== undefined){    
-        for (var key in self.yt_api_handler.streams_dict){
-            self.streams_list_to_display.push({id : key, label : self.yt_api_handler.streams_dict[key]});
-            }
-    }
+	if (self.yt_api_handler !== undefined){
+		for (var key in self.yt_api_handler.streams_dict){
+			self.streams_list_to_display.push({id : key, label : self.yt_api_handler.streams_dict[key]});
+			}
+	}
 
-    self.setActions({
-        "start_stream": {
-            label: "Start stream",
-            options: [{
-                type: "dropdown",
-                label: "Stream:",
-                id: "stream_to_start",
-                choices: self.streams_list_to_display
-            }]
-        },
-        "stop_stream": {
-            label: "Stop stream",
-            options: [{
-                type: "dropdown",
-                label: "Stream:",
-                id: "stream_to_stop",
-                choices: self.streams_list_to_display
-            }]
-        }
-    });
-    self.system.emit('instance_actions', self.id, self.setActions);
+	self.setActions({
+		"start_stream": {
+			label: "Start stream",
+			options: [{
+				type: "dropdown",
+				label: "Stream:",
+				id: "stream_to_start",
+				choices: self.streams_list_to_display
+			}]
+		},
+		"stop_stream": {
+			label: "Stop stream",
+			options: [{
+				type: "dropdown",
+				label: "Stream:",
+				id: "stream_to_stop",
+				choices: self.streams_list_to_display
+			}]
+		}
+	});
+	self.system.emit('instance_actions', self.id, self.setActions);
 };
 
 instance.prototype.action = function(action){
-    var self = this;
-    if (action.action == "start_stream"){
-        streams_starter = self.yt_api_handler.set_broadcast_live(action.options["stream_to_start"]);
-        streams_starter.then(response => {
-            self.log("info", "YouTube stream was set live successfully");
-            return;
-        });
-        streams_starter.catch(err => {
-            self.log("debug", "Error occured during stream state actualization, details: " + err);
-            return;
-        });
-    }
-    else if (action.action == "stop_stream"){
-        streams_stopper = self.yt_api_handler.set_broadcast_finished(action.options["stream_to_stop"]);
-        streams_stopper.then(response => {
-            self.log("info", "YouTube stream finished successfully");
-            return;
-        });
-        streams_stopper.catch(err => {
-            self.log("debug","Error occured during finishing a stream, details: " + err);
-            return;
-        });
-    }
+	var self = this;
+	if (action.action == "start_stream"){
+		streams_starter = self.yt_api_handler.set_broadcast_live(action.options["stream_to_start"]);
+		streams_starter.then(response => {
+			self.log("info", "YouTube stream was set live successfully");
+			return;
+		});
+		streams_starter.catch(err => {
+			self.log("debug", "Error occured during stream state actualization, details: " + err);
+			return;
+		});
+	}
+	else if (action.action == "stop_stream"){
+		streams_stopper = self.yt_api_handler.set_broadcast_finished(action.options["stream_to_stop"]);
+		streams_stopper.then(response => {
+			self.log("info", "YouTube stream finished successfully");
+			return;
+		});
+		streams_stopper.catch(err => {
+			self.log("debug","Error occured during finishing a stream, details: " + err);
+			return;
+		});
+	}
 }
 
 class Youtube_api_handler {
-    constructor(client_id, client_secret, redirect_url, scopes, token_path) {
-        this.streams_dict = {};
-        this.client_id = client_id;
-        this.client_secret = client_secret;
-        this.redirect_url = redirect_url;
-        this.scopes = scopes;
-        this.token_path = token_path;
-        this.oauth2client = new google.auth.OAuth2(
-            this.client_id,
-            this.client_secret,
-            this.redirect_url
-        );
-        google.options({auth: this.oauth2client});
-    }
-    async oauth_login() {
-        return new Promise((resolve, reject) => {
-            // grab the url that will be used for authorization
-            const authorizeUrl = this.oauth2client.generateAuthUrl({
-              access_type: 'offline',
-              scope: this.scopes.join(' '),
-            });
-            console.log(authorizeUrl);
-            const server = http
-              .createServer(async (req, res) => {
-                try {
-                    console.log(req.url);
-                    if (req.url.indexOf("code=") !== -1){
-                        const qs = new url.URL(req.url, 'http://localhost:3000')
-                        .searchParams;
-                        console.log(qs)
-                        res.end('Authentication successful! Please return to the Companion.');
-                        console.log("Code: " + qs.get("code"));
-                        const {tokens} = await this.oauth2client.getToken(qs.get('code'));
-                        console.log("Credentials: " + tokens);
-                        fs.writeFile(this.token_path, JSON.stringify(tokens), (error) => {
-                            if (error) return console.log("Error in saving token, details: " + error);
-                        });
-                        server.destroy();
-                        resolve(tokens);
-                    }
-                } catch (e) {
-                  console.log("Callback request processing error; " + req.url + " detail: " + e);
-                  reject(e);
-                }
-              })
-              .listen(3000, () => {
-                // open the browser to the authorize url to start the workflow
-                opn(authorizeUrl, {wait: false}).then(cp => cp.unref());
-              });
-            destroyer(server);
-            console.log("Server destroyed");
-          });
-        }
-    async create_yt_service() {
-        console.log("Creating youtube service.");
-        this.youtube_service = google.youtube({
-            version : "v3",
-            auth : this.oauth2client
-        });
-    }
-    async create_live_broadcast(title, scheduled_start_time, record_from_start, enable_dvr, privacy_status) {
-        return new Promise((resolve, reject) => {
-            this.youtube_service.liveBroadcasts.insert({
-                "part" : "snippet, contentDetails, staus",
-                "resource" : {
-                    "snippet" : {
-                        "title" : title,
-                        "scheduledStartTime" : scheduled_start_time,
-                    },
-                    "contentDetails" : {
-                        "recordFromStart" : record_from_start,
-                        "enableDvr" : enable_dvr
-                    },
-                    "status" : {
-                        "privacyStatus" : privacy_status
-                    }
-                }
-            }).then(function(response) {
-                console.log("Broadcast created successfully ; details: " + response);
-                resolve(response);
-            }, function(err) {
-                console.log("Error during execution of create live broadcast action ; details: " + err);
-                reject(err);
-            })
-        });
-    }
-    async create_live_stream(){}
+	constructor(client_id, client_secret, redirect_url, scopes, token_path) {
+		this.streams_dict = {};
+		this.client_id = client_id;
+		this.client_secret = client_secret;
+		this.redirect_url = redirect_url;
+		this.scopes = scopes;
+		this.token_path = token_path;
+		this.oauth2client = new google.auth.OAuth2(
+			this.client_id,
+			this.client_secret,
+			this.redirect_url
+		);
+		google.options({auth: this.oauth2client});
+	}
+	async oauth_login() {
+		return new Promise((resolve, reject) => {
+			// grab the url that will be used for authorization
+			const authorizeUrl = this.oauth2client.generateAuthUrl({
+			  access_type: 'offline',
+			  scope: this.scopes.join(' '),
+			});
+			console.log(authorizeUrl);
+			const server = http
+			  .createServer(async (req, res) => {
+				try {
+					console.log(req.url);
+					if (req.url.indexOf("code=") !== -1){
+						const qs = new url.URL(req.url, 'http://localhost:3000')
+						.searchParams;
+						console.log(qs)
+						res.end('Authentication successful! Please return to the Companion.');
+						console.log("Code: " + qs.get("code"));
+						const {tokens} = await this.oauth2client.getToken(qs.get('code'));
+						console.log("Credentials: " + tokens);
+						fs.writeFile(this.token_path, JSON.stringify(tokens), (error) => {
+							if (error) return console.log("Error in saving token, details: " + error);
+						});
+						server.destroy();
+						resolve(tokens);
+					}
+				} catch (e) {
+				  console.log("Callback request processing error; " + req.url + " detail: " + e);
+				  reject(e);
+				}
+			  })
+			  .listen(3000, () => {
+				// open the browser to the authorize url to start the workflow
+				opn(authorizeUrl, {wait: false}).then(cp => cp.unref());
+			  });
+			destroyer(server);
+			console.log("Server destroyed");
+		  });
+		}
+	async create_yt_service() {
+		console.log("Creating youtube service.");
+		this.youtube_service = google.youtube({
+			version : "v3",
+			auth : this.oauth2client
+		});
+	}
+	async create_live_broadcast(title, scheduled_start_time, record_from_start, enable_dvr, privacy_status) {
+		return new Promise((resolve, reject) => {
+			this.youtube_service.liveBroadcasts.insert({
+				"part" : "snippet, contentDetails, staus",
+				"resource" : {
+					"snippet" : {
+						"title" : title,
+						"scheduledStartTime" : scheduled_start_time,
+					},
+					"contentDetails" : {
+						"recordFromStart" : record_from_start,
+						"enableDvr" : enable_dvr
+					},
+					"status" : {
+						"privacyStatus" : privacy_status
+					}
+				}
+			}).then(function(response) {
+				console.log("Broadcast created successfully ; details: " + response);
+				resolve(response);
+			}, function(err) {
+				console.log("Error during execution of create live broadcast action ; details: " + err);
+				reject(err);
+			})
+		});
+	}
+	async create_live_stream(){}
 
-    async get_all_broadcasts() {
-        return new Promise((resolve, reject) => {
-            this.youtube_service.liveBroadcasts.list({
-                "part" : "snippet, contentDetails, status",
-                "broadcastType" : "all",
-                "mine" : true
-            }).then(function(response) {
-                let streams_dict = {};
-                response.data.items.forEach(function(item, index) {
-                    streams_dict[item.id] = item.snippet.title;
-                })
-                resolve(streams_dict);
-            }, function(err) {
-                Console.log("Error retreaving list of streams")
-                reject(err);
-            });
-        });
-    }
-    
-    async set_broadcast_live(id) {
-        return new Promise((resolve, reject) => {
-            this.youtube_service.liveBroadcasts.transition({
-                "part" : "snippet, contentDetails, status",
-                "id" : id,
-                "broadcastStatus" : "live"
-            }).then(function(response){
-                resolve(response);
-            }, function(err){
-                reject(err);
-            });
-        });
-    }
+	async get_all_broadcasts() {
+		return new Promise((resolve, reject) => {
+			this.youtube_service.liveBroadcasts.list({
+				"part" : "snippet, contentDetails, status",
+				"broadcastType" : "all",
+				"mine" : true
+			}).then(function(response) {
+				let streams_dict = {};
+				response.data.items.forEach(function(item, index) {
+					streams_dict[item.id] = item.snippet.title;
+				})
+				resolve(streams_dict);
+			}, function(err) {
+				Console.log("Error retreaving list of streams")
+				reject(err);
+			});
+		});
+	}
 
-    async set_broadcast_finished(id) {
-        return new Promise((resolve, reject) => {
-            this.youtube_service.liveBroadcasts.transition({
-                "part" : "snippet, contentDetails, status",
-                "id" : id,
-                "broadcastStatus" : "complete"
-            }).then(function(response){
-                resolve(response);
-            }, function(err) {
-                reject(err);
-            });
-        });
-    }
+	async set_broadcast_live(id) {
+		return new Promise((resolve, reject) => {
+			this.youtube_service.liveBroadcasts.transition({
+				"part" : "snippet, contentDetails, status",
+				"id" : id,
+				"broadcastStatus" : "live"
+			}).then(function(response){
+				resolve(response);
+			}, function(err){
+				reject(err);
+			});
+		});
+	}
+
+	async set_broadcast_finished(id) {
+		return new Promise((resolve, reject) => {
+			this.youtube_service.liveBroadcasts.transition({
+				"part" : "snippet, contentDetails, status",
+				"id" : id,
+				"broadcastStatus" : "complete"
+			}).then(function(response){
+				resolve(response);
+			}, function(err) {
+				reject(err);
+			});
+		});
+	}
 }
 
 
-instance_skel.extendedBy(instance); 
+instance_skel.extendedBy(instance);
 exports = module.exports = instance;

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ function instance(system, id, config) {
 	return self;
 };
 
-instance.prototype.updateConfig = function(config){
+instance.prototype.updateConfig = function(config) {
 	var self = this;
 	self.config = config;
 	console.log("Update config YT_module")
@@ -24,7 +24,7 @@ instance.prototype.updateConfig = function(config){
 	self.init();
 }
 
-instance.prototype.init = function(){
+instance.prototype.init = function() {
 	console.log("Init YT_module")
 	var self = this;
 	var yt_dir_path = self.config.path_to_yt_directory;
@@ -43,8 +43,8 @@ instance.prototype.init = function(){
 			var redirect_url = config_json["web"]["redirect_uris"][0];
 
 			self.yt_api_handler = new Youtube_api_handler(client_id, client_secret, redirect_url, scopes, token_path);
-			if (fs.existsSync(token_path)){
-				if (fs.lstatSync(token_path).isFile()){
+			if (fs.existsSync(token_path)) {
+				if (fs.lstatSync(token_path).isFile()) {
 					console.log("Token file (token.json) is provided");
 
 					fs.readFile(token_path, (error, token) => {
@@ -114,13 +114,13 @@ instance.prototype.init = function(){
 	}
 };
 
-instance.prototype.destroy = function(){
+instance.prototype.destroy = function() {
 	var self = this;
 	self.stream_to_start_list = [];
 	self.stream_to_stop_list = [];
 };
 
-instance.prototype.config_fields = function(){
+instance.prototype.config_fields = function() {
 	var self = this;
 	return [
 		{
@@ -140,15 +140,15 @@ instance.prototype.config_fields = function(){
 	]
 };
 
-instance.prototype.actions = function(system){
+instance.prototype.actions = function(system) {
 	var self = this;
 
 	self.streams_list_to_display = [];
 
-	if (self.yt_api_handler !== undefined){
-		for (var key in self.yt_api_handler.streams_dict){
+	if (self.yt_api_handler !== undefined) {
+		for (var key in self.yt_api_handler.streams_dict) {
 			self.streams_list_to_display.push({id : key, label : self.yt_api_handler.streams_dict[key]});
-			}
+		}
 	}
 
 	self.setActions({
@@ -174,9 +174,9 @@ instance.prototype.actions = function(system){
 	self.system.emit('instance_actions', self.id, self.setActions);
 };
 
-instance.prototype.action = function(action){
+instance.prototype.action = function(action) {
 	var self = this;
-	if (action.action == "start_stream"){
+	if (action.action == "start_stream") {
 		streams_starter = self.yt_api_handler.set_broadcast_live(action.options["stream_to_start"]);
 		streams_starter.then(response => {
 			self.log("info", "YouTube stream was set live successfully");
@@ -187,7 +187,7 @@ instance.prototype.action = function(action){
 			return;
 		});
 	}
-	else if (action.action == "stop_stream"){
+	else if (action.action == "stop_stream") {
 		streams_stopper = self.yt_api_handler.set_broadcast_finished(action.options["stream_to_stop"]);
 		streams_stopper.then(response => {
 			self.log("info", "YouTube stream finished successfully");
@@ -227,7 +227,7 @@ class Youtube_api_handler {
 			  .createServer(async (req, res) => {
 				try {
 					console.log(req.url);
-					if (req.url.indexOf("code=") !== -1){
+					if (req.url.indexOf("code=") !== -1) {
 						const qs = new url.URL(req.url, 'http://localhost:3000')
 						.searchParams;
 						console.log(qs)
@@ -287,7 +287,7 @@ class Youtube_api_handler {
 			})
 		});
 	}
-	async create_live_stream(){}
+	async create_live_stream() {}
 
 	async get_all_broadcasts() {
 		return new Promise((resolve, reject) => {
@@ -314,9 +314,9 @@ class Youtube_api_handler {
 				"part" : "snippet, contentDetails, status",
 				"id" : id,
 				"broadcastStatus" : "live"
-			}).then(function(response){
+			}).then(function(response) {
 				resolve(response);
-			}, function(err){
+			}, function(err) {
 				reject(err);
 			});
 		});
@@ -328,7 +328,7 @@ class Youtube_api_handler {
 				"part" : "snippet, contentDetails, status",
 				"id" : id,
 				"broadcastStatus" : "complete"
-			}).then(function(response){
+			}).then(function(response) {
 				resolve(response);
 			}, function(err) {
 				reject(err);

--- a/index.js
+++ b/index.js
@@ -1,10 +1,10 @@
 var instance_skel = require("../../instance_skel");
-const {google} = require("googleapis");
-var fs = require("fs");
-const url = require("url");
-const http = require("http");
-const opn = require("opn");
-const destroyer = require('server-destroy');
+const {google}    = require("googleapis");
+var fs            = require("fs");
+const url         = require("url");
+const http        = require("http");
+const opn         = require("opn");
+const destroyer   = require('server-destroy');
 
 function instance(system, id, config) {
 	var self = this;
@@ -27,20 +27,20 @@ instance.prototype.updateConfig = function(config) {
 instance.prototype.init = function() {
 	console.log("Init YT_module")
 	var self = this;
-	var yt_dir_path = self.config.path_to_yt_directory;
+	var yt_dir_path       = self.config.path_to_yt_directory;
 	var secrets_file_path = yt_dir_path + "client-secret.json";
-	var token_path = yt_dir_path + "token.json";
+	var token_path        = yt_dir_path + "token.json";
 
 	var scopes = ["https://www.googleapis.com/auth/youtube.force-ssl"];
 
 	if (yt_dir_path) {
 		if (fs.lstatSync(secrets_file_path).isFile()) {
-			var config_file = fs.readFileSync(secrets_file_path);
-			var config_json = JSON.parse(config_file);
-			var client_id = config_json["web"]["client_id"];
+			var config_file   = fs.readFileSync(secrets_file_path);
+			var config_json   = JSON.parse(config_file);
+			var client_id     = config_json["web"]["client_id"];
 			var client_secret = config_json["web"]["client_secret"];
 			console.log("client_seceret: " + client_secret);
-			var redirect_url = config_json["web"]["redirect_uris"][0];
+			var redirect_url  = config_json["web"]["redirect_uris"][0];
 
 			self.yt_api_handler = new Youtube_api_handler(client_id, client_secret, redirect_url, scopes, token_path);
 			if (fs.existsSync(token_path)) {
@@ -117,7 +117,7 @@ instance.prototype.init = function() {
 instance.prototype.destroy = function() {
 	var self = this;
 	self.stream_to_start_list = [];
-	self.stream_to_stop_list = [];
+	self.stream_to_stop_list  = [];
 };
 
 instance.prototype.config_fields = function() {
@@ -202,12 +202,12 @@ instance.prototype.action = function(action) {
 
 class Youtube_api_handler {
 	constructor(client_id, client_secret, redirect_url, scopes, token_path) {
-		this.streams_dict = {};
-		this.client_id = client_id;
+		this.streams_dict  = {};
+		this.client_id     = client_id;
 		this.client_secret = client_secret;
-		this.redirect_url = redirect_url;
-		this.scopes = scopes;
-		this.token_path = token_path;
+		this.redirect_url  = redirect_url;
+		this.scopes        = scopes;
+		this.token_path    = token_path;
 		this.oauth2client = new google.auth.OAuth2(
 			this.client_id,
 			this.client_secret,

--- a/index.js
+++ b/index.js
@@ -34,8 +34,13 @@ instance.prototype.init = function() {
 	var scopes = ["https://www.googleapis.com/auth/youtube.force-ssl"];
 
 	if (yt_dir_path) {
-		if (fs.lstatSync(secrets_file_path).isFile()) {
-			var config_file   = fs.readFileSync(secrets_file_path);
+		fs.readFile(secrets_file_path, (err, config_file) => {
+			if (err) {
+				self.log("warn", "Cannot load app OAuth credentials, " + err);
+				self.status(self.STATUS_ERROR, "Cannot load app OAuth credentials, " + err);
+				return;
+			}
+
 			var config_json   = JSON.parse(config_file);
 			var client_id     = config_json["web"]["client_id"];
 			var client_secret = config_json["web"]["client_secret"];
@@ -107,7 +112,7 @@ instance.prototype.init = function() {
 					promise.catch(console.error);
 			}
 
-		}
+		});
 
 	} else {
 		console.error("Path to YouTube operating directory is not provided");

--- a/package.json
+++ b/package.json
@@ -1,22 +1,22 @@
 {
-  "name": "youtube-live",
-  "version": "1.0.0",
-  "api_version": "1.0.0",
-  "description": "Simple module for controlling YT streaming",
-  "main": "index.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
-  "keywords": [
-    "Stream"
-  ],
-  "manufacturer": "Google (YouTube)",
-  "product": "YouTube",
-  "shortname": "YT",
-  "author": "Matěj Melichna",
-  "license": "ISC",
-  "dependencies": {
-    "googleapis": "^48.0.0",
-    "server-destroy": "^1.0.1"
-  }
+	"name": "youtube-live",
+	"version": "1.0.0",
+	"api_version": "1.0.0",
+	"description": "Simple module for controlling YT streaming",
+	"main": "index.js",
+	"scripts": {
+		"test": "echo \"Error: no test specified\" && exit 1"
+	},
+	"keywords": [
+		"Stream"
+	],
+	"manufacturer": "Google (YouTube)",
+	"product": "YouTube",
+	"shortname": "YT",
+	"author": "Matěj Melichna",
+	"license": "ISC",
+	"dependencies": {
+		"googleapis": "^48.0.0",
+		"server-destroy": "^1.0.1"
+	}
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "yt_module",
+  "name": "youtube-live",
   "version": "1.0.0",
   "api_version": "1.0.0",
   "description": "Simple module for controlling YT streaming",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "yt_module",
   "version": "1.0.0",
+  "api_version": "1.0.0",
   "description": "Simple module for controlling YT streaming",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This PR refactors the initialization procedure.

- broadcast list fetching code is deduplicated by creating `initApiDirectly()` and `initApiWithLogin()` functions
- cleaner code is achieved by removing file existence check via "asking forgiveness rather than permission"
- more errors are handled (JSON parse errors etc.)
- feedback via self.log() and self.status() is provided in the whole initialization procedure

Merge after #5 (this PR is built on top of it to prevent merge conflict)