### PR TITLE
fix: always request OAuth2 user consent to get refresh token

### DIFF
--- a/index.js
+++ b/index.js
@@ -247,6 +247,7 @@ class Youtube_api_handler {
 			// grab the url that will be used for authorization
 			const authorizeUrl = this.oauth2client.generateAuthUrl({
 			  access_type: 'offline',
+			  prompt: 'consent',
 			  scope: this.scopes.join(' '),
 			});
 


### PR DESCRIPTION
The authentication server only returns refresh_token if explicit consent was given for this request. If the permission grant was reused from previous requests, then only access_token is given and Companion fails to re-authenticate after access_token expiry (which is quite short).

Found at https://stackoverflow.com/a/8942732

Fixes #15