### PR TITLE
Add confirmation buttons

### DIFF
--- a/index.js
+++ b/index.js
@@ -192,6 +192,11 @@ instance.prototype.actions = function(system) {
 				label: "Stream:",
 				id: "stream_to_start",
 				choices: self.streams_list_to_display
+			}, {
+				type: "checkbox",
+				label: "Require confirmation",
+				id: "confirm",
+				default: false
 			}]
 		},
 		"stop_stream": {
@@ -201,6 +206,11 @@ instance.prototype.actions = function(system) {
 				label: "Stream:",
 				id: "stream_to_stop",
 				choices: self.streams_list_to_display
+			}, {
+				type: "checkbox",
+				label: "Require confirmation",
+				id: "confirm",
+				default: false
 			}]
 		}
 	});

--- a/index.js
+++ b/index.js
@@ -32,6 +32,7 @@ instance.prototype.init = function() {
 	self.status(self.STATUS_WARN, 'Initializing');
 
 	self.confirm_queue = [];
+	self.feedbacks();
 	self.variables();
 
 	var scopes = ["https://www.googleapis.com/auth/youtube.force-ssl"];
@@ -287,6 +288,7 @@ instance.prototype.enqueue_for_confirmation = function(job) {
 
 	self.confirm_queue.push(job);
 	self.setVariable('queue_depth', self.confirm_queue.length);
+	self.checkFeedbacks('queue_active');
 }
 
 instance.prototype.perform_queued = async function() {
@@ -305,6 +307,44 @@ instance.prototype.cancel_queued = function() {
 
 	self.confirm_queue = [];
 	self.setVariable('queue_depth', 0);
+	self.checkFeedbacks('queue_active');
+}
+
+instance.prototype.feedbacks = function() {
+	var self = this;
+
+	self.setFeedbackDefinitions({
+		"queue_active": {
+			label:       "Confirmation highlighter",
+			description: "Highlights pending jobs for confirmation",
+			options: [{
+				type:  "colorpicker",
+				label: "Active - background",
+				id:    "alert_bg",
+				default: this.rgb(255, 0, 0)
+			}, {
+				type:  "colorpicker",
+				label: "Active - foreground",
+				id:    "alert_fg",
+				default: this.rgb(255, 255, 255)
+			}]
+		}
+	});
+}
+
+instance.prototype.feedback = function(event) {
+	var self = this;
+
+	if (event.type == "queue_active") {
+		if (self.confirm_queue.length > 0) {
+			return {
+				color:   event.options.alert_fg,
+				bgcolor: event.options.alert_bg
+			}
+		}
+	}
+
+	return {};
 }
 
 instance.prototype.variables = function() {

--- a/index.js
+++ b/index.js
@@ -32,6 +32,7 @@ instance.prototype.init = function() {
 	self.status(self.STATUS_WARN, 'Initializing');
 
 	self.confirm_queue = [];
+	self.variables();
 
 	var scopes = ["https://www.googleapis.com/auth/youtube.force-ssl"];
 
@@ -285,6 +286,7 @@ instance.prototype.enqueue_for_confirmation = function(job) {
 	var self = this;
 
 	self.confirm_queue.push(job);
+	self.setVariable('queue_depth', self.confirm_queue.length);
 }
 
 instance.prototype.perform_queued = async function() {
@@ -302,6 +304,20 @@ instance.prototype.cancel_queued = function() {
 	var self = this;
 
 	self.confirm_queue = [];
+	self.setVariable('queue_depth', 0);
+}
+
+instance.prototype.variables = function() {
+	var self = this;
+
+	self.setVariableDefinitions([
+		{
+			label: "Number of queued jobs",
+			name:  "queue_depth"
+		}
+	]);
+
+	self.setVariable("queue_depth", 0);
 }
 
 class Youtube_api_handler {

--- a/index.js
+++ b/index.js
@@ -214,6 +214,12 @@ instance.prototype.actions = function(system) {
 				id: "confirm",
 				default: false
 			}]
+		},
+		"queue_confirm": {
+			label: "Confirm all pending jobs"
+		},
+		"queue_cancel": {
+			label: "Cancel all pending jobs"
 		}
 	});
 	self.system.emit('instance_actions', self.id, self.setActions);
@@ -252,6 +258,15 @@ instance.prototype.action = function(action) {
 				});
 			}
 		};
+
+	} else if (action.action == "queue_confirm") {
+		self.log("debug", "Running job queue");
+		self.perform_queued();
+
+	} else if (action.action == "queue_cancel") {
+		self.log("debug", "Dropping job queue");
+		self.cancel_queued();
+
 	}
 
 	if (job != null) {
@@ -270,6 +285,23 @@ instance.prototype.enqueue_for_confirmation = function(job) {
 	var self = this;
 
 	self.confirm_queue.push(job);
+}
+
+instance.prototype.perform_queued = async function() {
+	var self = this;
+
+	var queued = self.confirm_queue;
+	self.cancel_queued();
+
+	for (const item of queued) {
+		await item.perform();
+	}
+}
+
+instance.prototype.cancel_queued = function() {
+	var self = this;
+
+	self.confirm_queue = [];
 }
 
 class Youtube_api_handler {


### PR DESCRIPTION
Fixes https://github.com/bitfocus/companion-module-youtube-live/issues/21

This PR adds a queuing and confirm/cancel mechanism to this module. This is achieved by keeping a queue of "work" objects which are processed after "confirm" is pressed.

Sample configuration: https://youtu.be/u-0x91ZNFLM