### PR TITLE
feat: add "toggle stream" action

### DIFF
--- a/index.js
+++ b/index.js
@@ -230,6 +230,19 @@ instance.prototype.action = function(action) {
 	}
 }
 
+// https://developers.google.com/youtube/v3/live/docs/liveBroadcasts#status.lifeCycleStatus
+const StreamLifecycle = {
+	Revoked: 'revoked',
+	Created: 'created',
+	Ready:   'ready',
+	TestStarting: 'testStarting',
+	TestRunning:  'testing',
+	LiveStarting: 'liveStarting',
+	LiveRunning:  'live',
+	Complete: 'complete'
+};
+Object.freeze(StreamLifecycle);
+
 class Youtube_api_handler {
 	constructor(client_id, client_secret, redirect_url, scopes, log) {
 		this.streams_dict  = {};

--- a/index.js
+++ b/index.js
@@ -345,6 +345,23 @@ class Youtube_api_handler {
 
 	async create_live_stream() {}
 
+	async get_broadcast(id) {
+		let response = await this.youtube_service.liveBroadcasts.list({
+			"part": "snippet, contentDetails, status",
+			"id": id
+		});
+
+		if (response.data.items.length < 1) {
+			throw new Error("No stream found with ID " + id);
+
+		} else if (response.data.items.length > 1) {
+			throw new Error("Two or more streams found with ID " + id);
+
+		} else {
+			return response.data.items[0];
+		}
+	}
+
 	async get_all_broadcasts() {
 		return new Promise((resolve, reject) => {
 			this.youtube_service.liveBroadcasts.list({

--- a/index.js
+++ b/index.js
@@ -316,30 +316,23 @@ class Youtube_api_handler {
 			auth : this.oauth2client
 		});
 	}
+
 	async create_live_broadcast(title, scheduled_start_time, record_from_start, enable_dvr, privacy_status) {
-		return new Promise((resolve, reject) => {
-			this.youtube_service.liveBroadcasts.insert({
-				"part" : "snippet, contentDetails, staus",
-				"resource" : {
-					"snippet" : {
-						"title" : title,
-						"scheduledStartTime" : scheduled_start_time,
-					},
-					"contentDetails" : {
-						"recordFromStart" : record_from_start,
-						"enableDvr" : enable_dvr
-					},
-					"status" : {
-						"privacyStatus" : privacy_status
-					}
+		return this.youtube_service.liveBroadcasts.insert({
+			"part" : "snippet, contentDetails, staus",
+			"resource" : {
+				"snippet" : {
+					"title" : title,
+					"scheduledStartTime" : scheduled_start_time,
+				},
+				"contentDetails" : {
+					"recordFromStart" : record_from_start,
+					"enableDvr" : enable_dvr
+				},
+				"status" : {
+					"privacyStatus" : privacy_status
 				}
-			}).then( response => {
-				this.log('debug', "Broadcast created successfully ; details: " + response);
-				resolve(response);
-			}, err => {
-				this.log('warn', "Error during execution of create live broadcast action ; details: " + err);
-				reject(err);
-			})
+			}
 		});
 	}
 
@@ -363,49 +356,32 @@ class Youtube_api_handler {
 	}
 
 	async get_all_broadcasts() {
-		return new Promise((resolve, reject) => {
-			this.youtube_service.liveBroadcasts.list({
-				"part" : "snippet, contentDetails, status",
-				"broadcastType" : "all",
-				"mine" : true
-			}).then( response => {
-				let streams_dict = {};
-				response.data.items.forEach( (item, index) => {
-					streams_dict[item.id] = item.snippet.title;
-				})
-				resolve(streams_dict);
-			}, err => {
-				this.log('warn', "Error retrieving list of streams: " + err)
-				reject(err);
-			});
+		let response = await this.youtube_service.liveBroadcasts.list({
+			"part" : "snippet, contentDetails, status",
+			"broadcastType" : "all",
+			"mine" : true
 		});
+
+		let streams_dict = {};
+		response.data.items.forEach( (item, index) => {
+			streams_dict[item.id] = item.snippet.title;
+		})
+		return streams_dict;
 	}
 
 	async set_broadcast_live(id) {
-		return new Promise((resolve, reject) => {
-			this.youtube_service.liveBroadcasts.transition({
-				"part" : "snippet, contentDetails, status",
-				"id" : id,
-				"broadcastStatus" : "live"
-			}).then( response => {
-				resolve(response);
-			}, err => {
-				reject(err);
-			});
+		return this.youtube_service.liveBroadcasts.transition({
+			"part" : "snippet, contentDetails, status",
+			"id" : id,
+			"broadcastStatus" : "live"
 		});
 	}
 
 	async set_broadcast_finished(id) {
-		return new Promise((resolve, reject) => {
-			this.youtube_service.liveBroadcasts.transition({
-				"part" : "snippet, contentDetails, status",
-				"id" : id,
-				"broadcastStatus" : "complete"
-			}).then( response => {
-				resolve(response);
-			}, err => {
-				reject(err);
-			});
+		return this.youtube_service.liveBroadcasts.transition({
+			"part" : "snippet, contentDetails, status",
+			"id" : id,
+			"broadcastStatus" : "complete"
 		});
 	}
 }


### PR DESCRIPTION
This PR adds an action for toggling stream state. This basically starts an unstarted stream and finishes a running stream.

To do this, the YouTube API is called first to determine current stream status. Based on that the corresponding action is performed or an error is thrown when no transition makes sense.

As part of this PR I have also flattened the async functions to use await or return an "implicit" promise instead of returning an "explicit" promise.

Fixes https://github.com/bitfocus/companion-module-youtube-live/issues/22