### PR TITLE
feat: add action for initializing live broadcasts

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -7,9 +7,14 @@ So all broadcasts to be controlled by the module have to be created in the YouTu
 
 ### Available actions
 
-- **Start a broadcast**  - this action starts a YouTube broadcast and makes it available for viewing.
-- **Stop a broadcast**   - this action finishes a YouTube broadcast.
-- **Toggle a broadcast** - this action either starts or stops a broadcast, depending on current broadcast state (`ready` → `live`, `live` → `completed`).
+- **Initialize a broadcast** - this action initializes a YouTube broadcast. You'll need to use this after you start sending data
+  to YouTube and before you use the *Start a broadcast* action. Alternatively you can just visit the Live Control Room
+  of the broadcast and that should initialize the stream too. The associated [YouTube API transition][ytapi] is `testing`.
+- **Start a broadcast**  - this action starts a YouTube broadcast and makes it available for the public. The associated [YouTube API transition][ytapi] is `live`.
+- **Stop a broadcast**   - this action finishes a YouTube broadcast. The associated [YouTube API transition][ytapi] is `completed`.
+- **Toggle a broadcast** - this action combines the above actions into one action (off → initialized → live → completed).
+
+[ytapi]: https://developers.google.com/youtube/v3/live/docs/liveBroadcasts/transition
 
 ### Configuration
 

--- a/index.js
+++ b/index.js
@@ -216,6 +216,15 @@ instance.prototype.actions = function(system) {
 	}
 
 	self.setActions({
+		"init_broadcast": {
+			label: "Initialize a broadcast",
+			options: [{
+				type: "dropdown",
+				label: "Broadcast:",
+				id: "broadcast_id",
+				choices: self.broadcasts_list_to_display
+			}]
+		},
 		"start_broadcast": {
 			label: "Start a broadcast",
 			options: [{
@@ -250,7 +259,18 @@ instance.prototype.actions = function(system) {
 instance.prototype.action = function(action) {
 	var self = this;
 
-	if (action.action == "start_broadcast") {
+	if (action.action == "init_broadcast") {
+		self.yt_api_handler.set_broadcast_state(
+			action.options["broadcast_id"],
+			BroadcastTransition.ToTesting
+		).then( response => {
+			self.log("info", "YouTube broadcast was initialized successfully");
+			self.update_streams_broadcasts_state();
+		}).catch( err => {
+			self.log("debug", "Error occured during broadcast state actualization, details: " + err);
+		});
+
+	else if (action.action == "start_broadcast") {
 		self.yt_api_handler.set_broadcast_state(
 			action.options["broadcast_id"],
 			BroadcastTransition.ToLive
@@ -605,7 +625,7 @@ class Youtube_api_handler {
 
 		let broadcasts_dict = {};
 		response.data.items.forEach( (item, index) => {
-			broadcasts_dict[item.id] = {"title" : item.snippet.title, "bound_stream_id" : item.contentDetails.boundStreamId}; 
+			broadcasts_dict[item.id] = {"title" : item.snippet.title, "bound_stream_id" : item.contentDetails.boundStreamId};
 		});
 		return broadcasts_dict;
 	}


### PR DESCRIPTION
This adds an action for moving `ready` broadcasts to the `testing` state. Without this, it is impossible to move a "cold" (`ready`) broadcast to the `live` state.

Fixes #35 