### PR TITLE
fix: parse received request url with url.parse()

### DIFF
--- a/src/__tests__/auth/httpListener.ts
+++ b/src/__tests__/auth/httpListener.ts
@@ -63,7 +63,7 @@ describe('HTTP module interaction', () => {
 		const promise = new HttpReceiver('abcd', 1234, log).getCode(jest.fn());
 		mockEvent.emit('listening');
 
-		const req1 = { url: 'http://abcd:1234/favicon.ico' };
+		const req1 = { url: '/favicon.ico' };
 		const res1 = {
 			writeHead: jest.fn().mockImplementation((status: number, headers: object) => {
 				expect(status).toBe(400);
@@ -75,7 +75,7 @@ describe('HTTP module interaction', () => {
 		};
 		mockEvent.emit('request', req1, res1);
 
-		const req2 = { url: 'http://abcd:1234/callback?code=authCode' };
+		const req2 = { url: '/callback?code=authCode' };
 		const res2 = {
 			writeHead: jest.fn().mockImplementation((status: number, headers: object) => {
 				expect(status).toBe(200);

--- a/src/auth/httpListener.ts
+++ b/src/auth/httpListener.ts
@@ -56,13 +56,18 @@ export class HttpReceiver {
 	private handleRequest(req: http.IncomingMessage, res: http.ServerResponse): void {
 		if (typeof req.url == 'undefined') return;
 
-		const address = new url.URL(req.url);
-		const code = address.searchParams.get('code');
+		const address = url.parse(req.url, true);
 
 		this.Log('debug', `Received HTTP request at ${address.pathname}`);
 
-		// favicon, etc.
-		if (!code) {
+		const codeFrag: string | string[] | undefined = address.query['code'];
+		let code: string;
+
+		if (typeof codeFrag == 'string') {
+			code = codeFrag;
+		} else if (Array.isArray(codeFrag) && codeFrag.length > 0) {
+			code = codeFrag[0]
+		} else {
 			this.Log('debug', 'HTTP request does not contain authorization code');
 			res.writeHead(400, { 'Content-Type': 'text/plain' });
 			res.end('Authorization token required');


### PR DESCRIPTION
*// context: this commit somehow got lost from the last PR; I don't know if I forgot to push it or if something is going on with GitHub, but anyways, here it goes*

- the string that Node gives us does not contain the host, procol or port parts of URL
- this makes new URL() fail, but url.parse() is fine with it
- let's therefore use `url.parse()` again