### PR TITLE
feat: add GitHub Actions for CI

### DIFF
--- a/.github/workflows/postcommit.yml
+++ b/.github/workflows/postcommit.yml
@@ -1,0 +1,37 @@
+name: Build + test
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Download Node.js 8.x
+      uses: actions/setup-node@v1
+      with:
+        node-version: 8.x
+
+    - name: Checkout Companion
+      uses: actions/checkout@v2
+      with:
+        repository: bitfocus/companion
+        path: ./
+        submodules: false
+
+    - name: Checkout this commit
+      uses: actions/checkout@v2
+      with:
+        path: ./lib/module/youtube-live
+
+    - name: Compile module
+      run: yarn install --frozen-lockfile
+      working-directory: ./lib/module/youtube-live
+
+    - name: Run unit tests
+      run: yarn test
+      working-directory: ./lib/module/youtube-live


### PR DESCRIPTION
Fixes https://github.com/bitfocus/companion-module-youtube-live/issues/46

It turns out that the companion-inherited directory layout is not a problem for the Actions DSL - the parent repository can be cloned into a subdirectory without any problems.