### PR TITLE
Support for fixed buttons with upcomming/planned broadcasts

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
 		"@types/jest": "^25.2.3",
 		"@types/node": "^12.19.3",
 		"@types/server-destroy": "^1.0.0",
+		"date-fns": "^2.24.0",
 		"googleapis": "^48.0.0",
 		"open": "^7.0.4",
 		"server-destroy": "^1.0.1"

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,3 +1,5 @@
+import { differenceInMinutes, parseISO } from 'date-fns';
+
 /** YouTube broadcast ID, e.g. dQw4w9WgXcQ */
 export type BroadcastID = string;
 
@@ -74,6 +76,9 @@ export interface Broadcast {
 
 	/** Whether the YouTube Studio monitor stream is enabled or not. */
 	MonitorStreamEnabled: boolean;
+
+	/** The date and time that the broadcast actually ended. . */
+	ActualEndTime: string | null;
 }
 
 /**
@@ -96,4 +101,19 @@ export interface StateMemory {
 
 	/** All fetched streams */
 	Streams: Record<StreamID, Stream>;
+}
+
+/** Filter only unfinished broadcasts */
+export function FilterUnfinishedBroadcast(broadcast: Broadcast): boolean {
+	// filter also for actualEndTime diff
+	let endedSomeTimeAgo = false;
+
+	if (broadcast.ActualEndTime) {
+		const ended = parseISO(broadcast.ActualEndTime);
+		endedSomeTimeAgo = differenceInMinutes(new Date(), ended) < 20;
+	}
+	return (
+		(broadcast.Status != BroadcastLifecycle.Complete && broadcast.Status != BroadcastLifecycle.Revoked) ||
+		endedSomeTimeAgo
+	);
 }

--- a/src/feedbacks.ts
+++ b/src/feedbacks.ts
@@ -5,7 +5,14 @@ import {
 	CompanionFeedbackEvent,
 	CompanionFeedbackResult,
 } from '../../../instance_skel_types';
-import { BroadcastMap, StateMemory, BroadcastLifecycle, StreamHealth, BroadcastID } from './cache';
+import {
+	BroadcastMap,
+	StateMemory,
+	BroadcastLifecycle,
+	StreamHealth,
+	BroadcastID,
+	FilterUnfinishedBroadcast,
+} from './cache';
 import { RGBFunction } from './common';
 
 /**
@@ -13,10 +20,16 @@ import { RGBFunction } from './common';
  * @param broadcasts Map of known broadcasts
  * @param rgb Function for computing RGB color codes
  */
-export function listFeedbacks(broadcasts: BroadcastMap, rgb: RGBFunction): CompanionFeedbacks {
+export function listFeedbacks(broadcasts: BroadcastMap, rgb: RGBFunction, unfinishedCnt: number): CompanionFeedbacks {
 	const broadcastEntries: DropdownChoice[] = Object.values(broadcasts).map(
 		(item): DropdownChoice => {
 			return { id: item.Id, label: item.Name };
+		}
+	);
+
+	const broadcastUnfinishedEntries: DropdownChoice[] = [...Array(unfinishedCnt).keys()].map(
+		(i): DropdownChoice => {
+			return { id: i + 1, label: `Unfinished/planned #${i}` };
 		}
 	);
 
@@ -89,11 +102,127 @@ export function listFeedbacks(broadcasts: BroadcastMap, rgb: RGBFunction): Compa
 					default: rgb(255, 0, 0),
 				},
 				{
+					type: 'colorpicker',
+					label: 'Text color',
+					id: 'text',
+					default: rgb(255, 255, 255),
+				},
+				{
 					type: 'dropdown',
 					label: 'Broadcast',
 					id: 'broadcast',
 					choices: broadcastEntries,
 					default: defaultBroadcast,
+				},
+			],
+		},
+		unfinished_broadcast_status: {
+			label: 'Unfinished/planned Broadcast status',
+			description: 'Feedback providing information about state of a broadcast in a broadcast lifecycle',
+			options: [
+				{
+					type: 'colorpicker',
+					label: 'Background color (ready)',
+					id: 'bg_ready',
+					default: rgb(209, 209, 0),
+				},
+				{
+					type: 'colorpicker',
+					label: 'Background color (testing)',
+					id: 'bg_testing',
+					default: rgb(0, 172, 0),
+				},
+				{
+					type: 'colorpicker',
+					label: 'Background color (live)',
+					id: 'bg_live',
+					default: rgb(222, 0, 0),
+				},
+				{
+					type: 'colorpicker',
+					label: 'Text color',
+					id: 'text',
+					default: rgb(255, 255, 255),
+				},
+				{
+					type: 'colorpicker',
+					label: 'Background color (complete)',
+					id: 'bg_complete',
+					default: rgb(87, 0, 87),
+				},
+				{
+					type: 'colorpicker',
+					label: 'Text color (complete)',
+					id: 'text_complete',
+					default: rgb(126, 126, 126),
+				},
+				{
+					type: 'dropdown',
+					label: 'Broadcast',
+					id: 'broadcast',
+					choices: broadcastUnfinishedEntries,
+					default: 1,
+				},
+			],
+		},
+		unfinished_broadcast_bound_stream_health: {
+			label: 'Health of stream bound to unfinished/planned broadcast',
+			description: 'Feedback reflecting the health of video stream bound to a broadcast',
+			options: [
+				{
+					type: 'colorpicker',
+					label: 'Background color (good)',
+					id: 'bg_good',
+					default: rgb(0, 204, 0),
+				},
+				{
+					type: 'colorpicker',
+					label: 'Text color (good)',
+					id: 'text_good',
+					default: rgb(255, 255, 255),
+				},
+				{
+					type: 'colorpicker',
+					label: 'Background color (ok)',
+					id: 'bg_ok',
+					default: rgb(204, 204, 0),
+				},
+				{
+					type: 'colorpicker',
+					label: 'Text color (ok)',
+					id: 'text_ok',
+					default: rgb(255, 255, 255),
+				},
+				{
+					type: 'colorpicker',
+					label: 'Background color (bad)',
+					id: 'bg_bad',
+					default: rgb(255, 102, 0),
+				},
+				{
+					type: 'colorpicker',
+					label: 'Text color (bad)',
+					id: 'text_bad',
+					default: rgb(255, 255, 255),
+				},
+				{
+					type: 'colorpicker',
+					label: 'Background color (No data)',
+					id: 'bg_no_data',
+					default: rgb(255, 0, 0),
+				},
+				{
+					type: 'colorpicker',
+					label: 'Text color (No data)',
+					id: 'text_no_data',
+					default: rgb(255, 255, 255),
+				},
+				{
+					type: 'dropdown',
+					label: 'Broadcast',
+					id: 'broadcast',
+					choices: broadcastUnfinishedEntries,
+					default: 1,
 				},
 			],
 		},
@@ -166,6 +295,83 @@ export function handleFeedback(
 				return { bgcolor: feedback.options.bg_bad as number };
 			case StreamHealth.NoData:
 				return { bgcolor: feedback.options.bg_no_data as number };
+		}
+	}
+
+	if (feedback.type === 'unfinished_broadcast_status') {
+		if (!feedback.options.broadcast) return {};
+		const id = (feedback.options.broadcast as number) - 1;
+
+		const unfinishedBroadcasts = Object.values(memory.Broadcasts).filter(FilterUnfinishedBroadcast);
+
+		// handle missing fields
+		feedback.options.bg_ready = feedback.options.bg_ready ?? rgb(209, 209, 0);
+		feedback.options.bg_testing = feedback.options.bg_testing ?? rgb(0, 172, 0);
+		feedback.options.bg_live = feedback.options.bg_live ?? rgb(222, 0, 0);
+		feedback.options.bg_complete = feedback.options.bg_complete ?? rgb(87, 0, 87);
+		feedback.options.text = feedback.options.text ?? rgb(255, 255, 255);
+		feedback.options.text_complete = feedback.options.text_complete ?? rgb(126, 126, 126);
+
+		if (unfinishedBroadcasts.length == 0 || id >= unfinishedBroadcasts.length) {
+			return {};
+		} else {
+			switch (unfinishedBroadcasts[id].Status) {
+				case BroadcastLifecycle.LiveStarting:
+					if (dimStarting)
+						return { bgcolor: feedback.options.bg_testing as number, color: feedback.options.text as number };
+					else return { bgcolor: feedback.options.bg_live as number, color: feedback.options.text as number };
+				case BroadcastLifecycle.Live:
+					return { bgcolor: feedback.options.bg_live as number, color: feedback.options.text as number };
+				case BroadcastLifecycle.TestStarting:
+					if (dimStarting)
+						return { bgcolor: feedback.options.bg_ready as number, color: feedback.options.text as number };
+					else return { bgcolor: feedback.options.bg_testing as number, color: feedback.options.text as number };
+				case BroadcastLifecycle.Testing:
+					return { bgcolor: feedback.options.bg_testing as number, color: feedback.options.text as number };
+				case BroadcastLifecycle.Complete:
+					return { bgcolor: feedback.options.bg_complete as number, color: feedback.options.text_complete as number };
+				case BroadcastLifecycle.Ready:
+					return { bgcolor: feedback.options.bg_ready as number, color: feedback.options.text as number };
+			}
+		}
+	}
+	if (feedback.type === 'unfinished_broadcast_bound_stream_health') {
+		if (!feedback.options.broadcast) return {};
+		const id = (feedback.options.broadcast as number) - 1;
+
+		const unfinishedBroadcasts = Object.values(memory.Broadcasts).filter(FilterUnfinishedBroadcast);
+
+		// handle missing fields
+		feedback.options.bg_good = feedback.options.bg_good ?? rgb(0, 204, 0);
+		feedback.options.text_good = feedback.options.text_good ?? rgb(255, 255, 255);
+		feedback.options.bg_ok = feedback.options.bg_ok ?? rgb(204, 204, 0);
+		feedback.options.text_ok = feedback.options.text_ok ?? rgb(255, 255, 255);
+		feedback.options.bg_bad = feedback.options.bg_bad ?? rgb(255, 102, 0);
+		feedback.options.text_bad = feedback.options.text_bad ?? rgb(255, 255, 255);
+		feedback.options.bg_no_data = feedback.options.bg_no_data ?? rgb(255, 0, 0);
+		feedback.options.text_no_data = feedback.options.text_no_data ?? rgb(255, 255, 255);
+
+		if (unfinishedBroadcasts.length == 0 || id >= unfinishedBroadcasts.length) {
+			return {};
+		} else {
+			const streamId = unfinishedBroadcasts[id].BoundStreamId;
+			if (streamId != null && streamId in memory.Streams) {
+				switch (memory.Streams[streamId].Health) {
+					case StreamHealth.Good:
+						return { bgcolor: feedback.options.bg_good as number, color: feedback.options.text_good as number };
+					case StreamHealth.OK:
+						return { bgcolor: feedback.options.bg_ok as number, color: feedback.options.text_ok as number };
+					case StreamHealth.Bad:
+						return { bgcolor: feedback.options.bg_bad as number, color: feedback.options.text_bad as number };
+					case StreamHealth.NoData:
+						if (unfinishedBroadcasts[id].Status == BroadcastLifecycle.Complete) {
+							return {};
+						}
+						return { bgcolor: feedback.options.bg_no_data as number, color: feedback.options.text_no_data as number };
+				}
+			} else {
+				return {};
+			}
 		}
 	}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -138,12 +138,13 @@ class YoutubeInstance extends InstanceSkel<YoutubeConfig> implements ModuleBase,
 	 * @param memory Known streams and broadcasts
 	 */
 	reloadAll(memory: StateMemory): void {
-		this.setVariableDefinitions(declareVars(memory));
-		for (const item of exportVars(memory)) {
+		const unfinishedCnt = 3;
+		this.setVariableDefinitions(declareVars(memory, unfinishedCnt));
+		for (const item of exportVars(memory, unfinishedCnt)) {
 			this.setVariable(item.name, item.value);
 		}
-		this.setPresetDefinitions(listPresets(memory.Broadcasts, this.rgb.bind(this)));
-		this.setFeedbackDefinitions(listFeedbacks(memory.Broadcasts, this.rgb.bind(this)));
+		this.setPresetDefinitions(listPresets(memory.Broadcasts, this.rgb.bind(this), unfinishedCnt));
+		this.setFeedbackDefinitions(listFeedbacks(memory.Broadcasts, this.rgb.bind(this), unfinishedCnt));
 		this.setActions(listActions(memory.Broadcasts));
 		this.checkFeedbacks();
 	}
@@ -153,7 +154,7 @@ class YoutubeInstance extends InstanceSkel<YoutubeConfig> implements ModuleBase,
 	 * @param memory Known streams and broadcasts
 	 */
 	reloadStates(memory: StateMemory): void {
-		for (const item of exportVars(memory)) {
+		for (const item of exportVars(memory, 3)) {
 			this.setVariable(item.name, item.value);
 		}
 		this.checkFeedbacks();
@@ -168,6 +169,7 @@ class YoutubeInstance extends InstanceSkel<YoutubeConfig> implements ModuleBase,
 			this.setVariable(item.name, item.value);
 		}
 		this.checkFeedbacks('broadcast_status');
+		this.checkFeedbacks('unfinished_broadcast_status');
 	}
 }
 

--- a/src/presets.ts
+++ b/src/presets.ts
@@ -8,7 +8,7 @@ import { RGBFunction } from './common';
  * @param broadcasts Map of known broadcasts
  * @param rgb Function for generating RGB color codes
  */
-export function listPresets(broadcasts: BroadcastMap, rgb: RGBFunction): CompanionPreset[] {
+export function listPresets(broadcasts: BroadcastMap, rgb: RGBFunction, unfinishedCnt: number): CompanionPreset[] {
 	const presets: CompanionPreset[] = [];
 
 	Object.values(broadcasts).forEach((item) => {
@@ -140,6 +140,65 @@ export function listPresets(broadcasts: BroadcastMap, rgb: RGBFunction): Compani
 			],
 		};
 		presets.push(start, stop, toggle, init);
+	});
+
+	[...Array(unfinishedCnt).keys()].forEach((i) => {
+		if (i < unfinishedCnt) {
+			const unfinished: CompanionPreset = {
+				category: 'Unfinished/planned broadcasts',
+				label: `Unfinished broadcast state/name #${i}`,
+				bank: {
+					style: 'text',
+					text: `$(YT:unfinished_state_${i})\\n$(yt:unfinished_short_${i})`,
+					size: 'auto',
+					color: rgb(125, 125, 125),
+					bgcolor: 0,
+				},
+				feedbacks: [
+					{
+						type: 'unfinished_broadcast_status',
+						options: {
+							bg_live: rgb(222, 0, 0),
+							bg_testing: rgb(0, 172, 0),
+							bg_complete: rgb(87, 0, 87),
+							text_complete: rgb(182, 155, 182),
+							bg_ready: rgb(209, 209, 0),
+							broadcast: i + 1,
+						},
+					},
+				],
+				actions: [],
+			};
+			const stream: CompanionPreset = {
+				category: 'Unfinished/planned broadcasts',
+				label: `Unfinished broadcast's stream health #${i}`,
+				bank: {
+					style: 'text',
+					text: `Stream #${i}\\n$(YT:unfinished_health_${i})`,
+					size: 'auto',
+					color: rgb(125, 125, 125),
+					bgcolor: 0,
+				},
+				feedbacks: [
+					{
+						type: 'unfinished_broadcast_bound_stream_health',
+						options: {
+							bg_good: rgb(0, 204, 0),
+							text_good: rgb(255, 255, 255),
+							bg_ok: rgb(204, 204, 0),
+							text_ok: rgb(255, 255, 255),
+							bg_bad: rgb(255, 102, 0),
+							text_bad: rgb(255, 255, 255),
+							bg_no_data: rgb(255, 0, 0),
+							text_no_data: rgb(255, 255, 255),
+							broadcast: i + 1,
+						},
+					},
+				],
+				actions: [],
+			};
+			presets.push(unfinished, stream);
+		}
 	});
 
 	return presets;

--- a/src/youtube.ts
+++ b/src/youtube.ts
@@ -98,6 +98,7 @@ export class YoutubeConnector implements YoutubeAPI {
 				Status: status,
 				BoundStreamId: item.contentDetails!.boundStreamId || null,
 				MonitorStreamEnabled: monitor,
+				ActualEndTime: item.snippet!.actualEndTime!,
 			};
 		});
 
@@ -109,7 +110,7 @@ export class YoutubeConnector implements YoutubeAPI {
 	 */
 	async refreshBroadcastStatus1(broadcast: Broadcast): Promise<Broadcast> {
 		const response = await this.ApiClient.liveBroadcasts.list({
-			part: 'status',
+			part: 'status, snippet',
 			id: broadcast.Id,
 			maxResults: 1,
 		});
@@ -126,6 +127,7 @@ export class YoutubeConnector implements YoutubeAPI {
 			Status: status,
 			BoundStreamId: broadcast.BoundStreamId,
 			MonitorStreamEnabled: broadcast.MonitorStreamEnabled,
+			ActualEndTime: item.snippet!.actualEndTime!,
 		};
 	}
 
@@ -134,7 +136,7 @@ export class YoutubeConnector implements YoutubeAPI {
 	 */
 	async refreshBroadcastStatus(current: BroadcastMap): Promise<BroadcastMap> {
 		const response = await this.ApiClient.liveBroadcasts.list({
-			part: 'status',
+			part: 'status, snippet',
 			id: Object.keys(current).join(','),
 			maxResults: this.MaxBroadcasts,
 		});
@@ -151,6 +153,7 @@ export class YoutubeConnector implements YoutubeAPI {
 				Status: status,
 				BoundStreamId: current[id].BoundStreamId,
 				MonitorStreamEnabled: current[id].MonitorStreamEnabled,
+				ActualEndTime: item.snippet!.actualEndTime!,
 			};
 		});
 


### PR DESCRIPTION
New presets/variables/feedbacks that will allow us having static buttons like ${upcoming_0}, ${upcoming_state_0}, etc... without the need of reconfiguring companion buttons before action in case operators need to see dashboard with current broadcast status.

I've wrote my ideas into https://github.com/bitfocus/companion-module-youtube-live/issues/62 but didnt implementing "actions" as parametrized functions, as this should be discussed by more advanced users if such behaviour is feasible.
