### PR TITLE
feat: send message to livechat improvement

### DIFF
--- a/companion/manifest.json
+++ b/companion/manifest.json
@@ -3,7 +3,7 @@
 	"name": "youtube-live",
 	"shortname": "YT",
 	"description": "Simple module for controlling YouTube live broadcasts",
-	"version": "2.2.0",
+	"version": "2.3.0",
 	"license": "MIT",
 	"repository": "git+https://github.com/bitfocus/companion-module-youtube-live.git",
 	"bugs": "https://github.com/bitfocus/companion-module-youtube-live/issues",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "youtube-live",
-	"version": "2.2.0",
+	"version": "2.3.0",
 	"main": "dist/index.js",
 	"license": "MIT",
 	"scripts": {

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -201,8 +201,12 @@ export function listActions(
 				},
 				{
 					type: 'textinput',
-					label: 'Message (max. 200 chars):',
+					label: 'Message:',
 					id: 'message_content',
+					required: true,
+					regex: '/^.{1,200}$/',
+					tooltip: 'Seize a message with a maximum length of 200 characters',
+					useVariables: true,
 				},
 			],
 			callback: async (event): Promise<void> => {


### PR DESCRIPTION
- `send message to live chat` feature improvement:
    - add tooltip for live chat message's text field
    - add visual hint if message is too long (regex based)
    - allow variables