### PR TITLE
Allow specifying the broadcast id from a text string (including incorporating variables)

### DIFF
--- a/src/__mocks__/context.ts
+++ b/src/__mocks__/context.ts
@@ -1,9 +1,34 @@
 import { CompanionActionContext, CompanionFeedbackContext } from '@companion-module/base';
 
+// https://github.com/bitfocus/companion/blob/bfe2e89d2fdbddf0d2347e73305e866c659ae412/companion/lib/Variables/Util.ts#L22
+const VARIABLE_REGEX = /\$\(([^:$)]+):([^)$]+)\)/;
+
 export class MockContext implements CompanionActionContext, CompanionFeedbackContext {
+	#variables = new Map<string, string>();
+
+	getVariable(name: string): string {
+		return this.#variables.get(name) ?? '$NA';
+	}
+
+	setVariable(name: string, value: string): void {
+		this.#variables.set(name, value);
+	}
+
+	clearVariables(): void {
+		this.#variables.clear();
+	}
+
 	async parseVariablesInString(text: string): Promise<string> {
 		return new Promise<string>((resolve) => {
-			resolve(text);
+			let result = text;
+
+			let match: RegExpExecArray | null;
+			while ((match = VARIABLE_REGEX.exec(result)) !== null) {
+				const [fullId, module, varname] = match;
+				result = result.replace(fullId, () => this.getVariable(`${module}:${varname}`));
+			}
+
+			resolve(result);
 		});
 	}
 }

--- a/src/__tests__/actions.ts
+++ b/src/__tests__/actions.ts
@@ -126,18 +126,28 @@ describe('Action callback', () => {
 
 	test('Start test success', async () => {
 		const context = new MockContext();
-		const event = makeEvent(ActionId.InitBroadcast, { broadcast_id: 'test' });
+		const event = makeEvent(ActionId.InitBroadcast, {
+			broadcast_id_is_text: false,
+			broadcast_id: 'test',
+			broadcast_id_text: 'BAD',
+		});
 		await expect(
 			actionsOK.init_broadcast.callback(event, context)
 		).resolves.toBeUndefined();
 		expect(coreOK.startBroadcastTest).toHaveBeenCalledTimes(1);
+		expect(coreOK.startBroadcastTest).toHaveBeenLastCalledWith('test');
 	});
 	test('Start test failure', async () => {
 		const context = new MockContext();
-		const event = makeEvent(ActionId.InitBroadcast, { broadcast_id: 'test' });
+		const event = makeEvent(ActionId.InitBroadcast, {
+			broadcast_id_is_text: true,
+			broadcast_id: 'BAD',
+			broadcast_id_text: 'test',
+		});
 		await expect(
 			actionsKO.init_broadcast.callback(event, context)
 		).rejects.toBeInstanceOf(Error);
+		expect(coreKO.startBroadcastTest).toHaveBeenLastCalledWith('test');
 		expect(coreKO.startBroadcastTest).toHaveBeenCalledTimes(1);
 	});
 	test('Missing broadcast ID', async () => {
@@ -151,65 +161,101 @@ describe('Action callback', () => {
 	});
 	test('Unknown broadcast ID', async () => {
 		const context = new MockContext();
-		const event = makeEvent(ActionId.InitBroadcast, { broadcast_id: 'random' });
+		const event = makeEvent(ActionId.InitBroadcast, {
+			broadcast_id_is_text: false,
+			broadcast_id: 'unknown-broadcast-id',
+			broadcast_id_text: 'test',
+		});
 		await expect(
 			actionsOK.init_broadcast.callback(event, context)
 		).resolves.toBeUndefined();
 		expect(coreOK.Module.log).toHaveBeenLastCalledWith(
 			'warn',
-			"Action failed: broadcast ID 'random' - not found or invalid"
+			"Action failed: broadcast ID 'unknown-broadcast-id' - not found or invalid"
 		);
 		expect(coreOK.startBroadcastTest).toHaveBeenCalledTimes(0);
 	});
 
 	test('Go live success', async () => {
 		const context = new MockContext();
-		const event = makeEvent(ActionId.StartBroadcast, { broadcast_id: 'test' });
+		const event = makeEvent(ActionId.StartBroadcast, {
+			broadcast_id_is_text: false,
+			broadcast_id: 'test',
+			broadcast_id_text: 'BAD',
+		});
 		await expect(
 			actionsOK.start_broadcast.callback(event, context)
 		).resolves.toBeUndefined();
+		expect(coreOK.makeBroadcastLive).toHaveBeenLastCalledWith('test');
 		expect(coreOK.makeBroadcastLive).toHaveBeenCalledTimes(1);
 	});
 	test('Go live failure', async () => {
 		const context = new MockContext();
-		const event = makeEvent(ActionId.StartBroadcast, { broadcast_id: 'test' });
+		const event = makeEvent(ActionId.StartBroadcast, {
+			broadcast_id_is_text: false,
+			broadcast_id: 'test',
+			broadcast_id_text: 'BAD',
+		});
 		await expect(
 			actionsKO.start_broadcast.callback(event, context)
 		).rejects.toBeInstanceOf(Error);
+		expect(coreKO.makeBroadcastLive).toHaveBeenLastCalledWith('test');
 		expect(coreKO.makeBroadcastLive).toHaveBeenCalledTimes(1);
 	});
 
 	test('Finish success', async () => {
 		const context = new MockContext();
-		const event = makeEvent(ActionId.StopBroadcast, { broadcast_id: 'test' });
+		context.setVariable('mod:var', 'tes');
+
+		const event = makeEvent(ActionId.StopBroadcast, {
+			broadcast_id_is_text: true,
+			broadcast_id: 'BAD',
+			broadcast_id_text: '$(mod:var)t',
+		});
 		await expect(
 			actionsOK.stop_broadcast.callback(event, context)
 		).resolves.toBeUndefined();
+		expect(coreOK.finishBroadcast).toHaveBeenLastCalledWith('test');
 		expect(coreOK.finishBroadcast).toHaveBeenCalledTimes(1);
 	});
 	test('Finish failure', async () => {
 		const context = new MockContext();
-		const event = makeEvent(ActionId.StopBroadcast, { broadcast_id: 'test' });
+		const event = makeEvent(ActionId.StopBroadcast, {
+			broadcast_id_is_text: false,
+			broadcast_id: 'test',
+			broadcast_id_text: 'BAD',
+		});
 		await expect(
 			actionsKO.stop_broadcast.callback(event, context)
 		).rejects.toBeInstanceOf(Error);
+		expect(coreKO.finishBroadcast).toHaveBeenLastCalledWith('test');
 		expect(coreKO.finishBroadcast).toHaveBeenCalledTimes(1);
 	});
 
 	test('Toggle success', async () => {
 		const context = new MockContext();
-		const event = makeEvent(ActionId.ToggleBroadcast, { broadcast_id: 'test' });
+		const event = makeEvent(ActionId.ToggleBroadcast, {
+			broadcast_id_is_text: false,
+			broadcast_id: 'test',
+			broadcast_id_text: 'BAD',
+		});
 		await expect(
 			actionsOK.toggle_broadcast.callback(event, context)
 		).resolves.toBeUndefined();
+		expect(coreOK.toggleBroadcast).toHaveBeenLastCalledWith('test');
 		expect(coreOK.toggleBroadcast).toHaveBeenCalledTimes(1);
 	});
 	test('Toggle failure', async () => {
 		const context = new MockContext();
-		const event = makeEvent(ActionId.ToggleBroadcast, { broadcast_id: 'test' });
+		const event = makeEvent(ActionId.ToggleBroadcast, {
+			broadcast_id_is_text: false,
+			broadcast_id: 'test',
+			broadcast_id_text: 'BAD',
+		});
 		await expect(
 			actionsKO.toggle_broadcast.callback(event, context)
 		).rejects.toBeInstanceOf(Error);
+		expect(coreKO.toggleBroadcast).toHaveBeenLastCalledWith('test');
 		expect(coreKO.toggleBroadcast).toHaveBeenCalledTimes(1);
 	});
 
@@ -249,126 +295,226 @@ describe('Action callback', () => {
 
 	test('Send message success', async () => {
 		const context = new MockContext();
-		const event = makeEvent(ActionId.SendMessage, { broadcast_id: 'test', message_content: 'testing message' });
+		const event = makeEvent(ActionId.SendMessage, {
+			broadcast_id_is_text: false,
+			broadcast_id: 'test',
+			broadcast_id_text: 'BAD',
+			message_content: 'testing message',
+		});
 		await expect(
 			actionsOK.send_livechat_message.callback(event, context)
 		).resolves.toBeUndefined();
+		expect(coreOK.sendLiveChatMessage).toHaveBeenLastCalledWith('test', 'testing message');
 		expect(coreOK.sendLiveChatMessage).toHaveBeenCalledTimes(1);
 	});
 	test('Send message failure', async () => {
 		const context = new MockContext();
-		const event = makeEvent(ActionId.SendMessage, { broadcast_id: 'test', message_content: 'testing message' });
+		context.setVariable('ex:lax', 'ting mes');
+		context.setVariable('semi:punctuation', 'e');
+
+		const event = makeEvent(ActionId.SendMessage, {
+			broadcast_id_is_text: true,
+			broadcast_id: 'BAD',
+			broadcast_id_text: 't$(semi:punctuation)st',
+			message_content: 'tes$(ex:lax)sage',
+		});
 		await expect(
 			actionsKO.send_livechat_message.callback(event, context)
 		).rejects.toBeInstanceOf(Error);
+		expect(coreKO.sendLiveChatMessage).toHaveBeenLastCalledWith('test', 'testing message');
 		expect(coreKO.sendLiveChatMessage).toHaveBeenCalledTimes(1);
 	});
 
 	test('Insert cue point success', async () => {
 		const context = new MockContext();
-		const event = makeEvent(ActionId.InsertCuePoint, { broadcast_id: 'test' });
+		const event = makeEvent(ActionId.InsertCuePoint, {
+			broadcast_id_is_text: false,
+			broadcast_id: 'test',
+			broadcast_id_text: 'BAD',
+		});
 		await expect(
 			actionsOK.insert_cue_point.callback(event, context)
 		).resolves.toBeUndefined();
+		expect(coreOK.insertCuePoint).toHaveBeenLastCalledWith('test');
 		expect(coreOK.insertCuePoint).toHaveBeenCalledTimes(1);
 	});
 	test('Insert cue point failure', async () => {
 		const context = new MockContext();
-		const event = makeEvent(ActionId.InsertCuePoint, { broadcast_id: 'test' });
+		const event = makeEvent(ActionId.InsertCuePoint, {
+			broadcast_id_is_text: false,
+			broadcast_id: 'test',
+			broadcast_id_text: 'BAD',
+		});
 		await expect(
 			actionsKO.insert_cue_point.callback(event, context)
 		).rejects.toBeInstanceOf(Error);
+		expect(coreKO.insertCuePoint).toHaveBeenLastCalledWith('test');
 		expect(coreKO.insertCuePoint).toHaveBeenCalledTimes(1);
 	});
 	test('Insert custom cue point success', async () => {
 		const context = new MockContext();
-		const event = makeEvent(ActionId.InsertCuePoint, { broadcast_id: 'test', duration: 10 });
+		const event = makeEvent(ActionId.InsertCuePoint, {
+			broadcast_id_is_text: true,
+			broadcast_id: 'BAD',
+			broadcast_id_text: 'test',
+			duration: 10,
+		});
 		await expect(
 			actionsOK.insert_cue_point_custom_duration.callback(event, context)
 		).resolves.toBeUndefined();
+		expect(coreOK.insertCuePoint).toHaveBeenLastCalledWith('test', 10);
 		expect(coreOK.insertCuePoint).toHaveBeenCalledTimes(1);
 	});
 	test('Insert custom cue point failure', async () => {
 		const context = new MockContext();
-		const event = makeEvent(ActionId.InsertCuePoint, { broadcast_id: 'test', duration: 10 });
+		const event = makeEvent(ActionId.InsertCuePoint, {
+			broadcast_id_is_text: true,
+			broadcast_id: 'BAD',
+			broadcast_id_text: 'test',
+			duration: 10,
+		});
 		await expect(
 			actionsKO.insert_cue_point_custom_duration.callback(event, context)
 		).rejects.toBeInstanceOf(Error);
+		expect(coreKO.insertCuePoint).toHaveBeenLastCalledWith('test', 10);
 		expect(coreKO.insertCuePoint).toHaveBeenCalledTimes(1);
 	});
 
 	test('Set title success', async () => {
 		const context = new MockContext();
-		const event = makeEvent(ActionId.SetTitle, { broadcast_id: 'test', title_content: 'Test Broadcast (updated title)' });
+		const UpdatedTitle = 'Test Broadcast (updated title)';
+		const event = makeEvent(ActionId.SetTitle, {
+			broadcast_id_is_text: true,
+			broadcast_id: 'BAD',
+			broadcast_id_text: 'test',
+			title_content: UpdatedTitle,
+		});
 		await expect(
 			actionsOK.set_title.callback(event, context)
 		).resolves.toBeUndefined();
+		expect(coreOK.setTitle).toHaveBeenLastCalledWith('test', UpdatedTitle);
 		expect(coreOK.setTitle).toHaveBeenCalledTimes(1);
 	});
 	test('Set title failure', async () => {
 		const context = new MockContext();
-		const event = makeEvent(ActionId.SetTitle, { broadcast_id: 'test', title_content: 'Test Broadcast (updated title)' });
+		const UpdatedTitle = 'Test Broadcast (updated title)';
+		const event = makeEvent(ActionId.SetTitle, {
+			broadcast_id_is_text: false,
+			broadcast_id: 'test',
+			broadcast_id_text: 'BAD',
+			title_content: UpdatedTitle,
+		});
 		await expect(
 			actionsKO.set_title.callback(event, context)
 		).rejects.toBeInstanceOf(Error);
+		expect(coreKO.setTitle).toHaveBeenLastCalledWith('test', UpdatedTitle);
 		expect(coreKO.setTitle).toHaveBeenCalledTimes(1);
 	});
 
 	test('Set description success', async () => {
 		const context = new MockContext();
-		const event = makeEvent(ActionId.SetDescription, { broadcast_id: 'test', desc_content: 'description' });
+		const event = makeEvent(ActionId.SetDescription, {
+			broadcast_id_is_text: true,
+			broadcast_id: 'BAD',
+			broadcast_id_text: 'test',
+			desc_content: 'description',
+		});
 		await expect(
 			actionsOK.set_description.callback(event, context)
 		).resolves.toBeUndefined();
+		expect(coreOK.setDescription).toHaveBeenLastCalledWith('test', 'description');
 		expect(coreOK.setDescription).toHaveBeenCalledTimes(1);
 	});
 	test('Set description failure', async () => {
 		const context = new MockContext();
-		const event = makeEvent(ActionId.SetDescription, { broadcast_id: 'test', desc_content: 'description' });
+		const event = makeEvent(ActionId.SetDescription, {
+			broadcast_id_is_text: false,
+			broadcast_id: 'test',
+			broadcast_id_text: 'BAD',
+			desc_content: 'description',
+		});
 		await expect(
 			actionsKO.set_description.callback(event, context)
 		).rejects.toBeInstanceOf(Error);
+		expect(coreKO.setDescription).toHaveBeenLastCalledWith('test', 'description');
 		expect(coreKO.setDescription).toHaveBeenCalledTimes(1);
 	});
 	test('Prepend to description success', async () => {
 		const context = new MockContext();
-		const event = makeEvent(ActionId.PrependToDescription, { broadcast_id: 'test', text: 'text to prepend' });
+		context.setVariable('mod:var', 's');
+
+		const event = makeEvent(ActionId.PrependToDescription, {
+			broadcast_id_is_text: true,
+			broadcast_id: 'BAD',
+			broadcast_id_text: 'te$(mod:var)t',
+			text: 'text$(mod:var) to prepend',
+		});
 		await expect(
 			actionsOK.preprend_to_description.callback(event, context)
 		).resolves.toBeUndefined();
+		expect(coreOK.prependToDescription).toHaveBeenLastCalledWith('test', 'texts to prepend');
 		expect(coreOK.prependToDescription).toHaveBeenCalledTimes(1);
 	});
 	test('Prepend to description failure', async () => {
 		const context = new MockContext();
-		const event = makeEvent(ActionId.PrependToDescription, { broadcast_id: 'test', text: 'text to prepend' });
+		const event = makeEvent(ActionId.PrependToDescription, {
+			broadcast_id_is_text: false,
+			broadcast_id: 'test',
+			broadcast_id_text: 'BAD',
+			text: 'text to prepend',
+		});
 		await expect(
 			actionsKO.preprend_to_description.callback(event, context)
 		).rejects.toBeInstanceOf(Error);
+		expect(coreKO.prependToDescription).toHaveBeenLastCalledWith('test', 'text to prepend');
 		expect(coreKO.prependToDescription).toHaveBeenCalledTimes(1);
 	});
 	test('Append to description success', async () => {
 		const context = new MockContext();
-		const event = makeEvent(ActionId.AppendToDescription, { broadcast_id: 'test', text: 'text to append' });
+		context.setVariable('hello:hello', 'st');
+
+		const TextToAppend = 'text to append';
+		const event = makeEvent(ActionId.AppendToDescription, {
+			broadcast_id_is_text: true,
+			broadcast_id: 'BAD',
+			broadcast_id_text: 'te$(hello:hello)',
+			text: TextToAppend,
+		});
 		await expect(
 			actionsOK.append_to_description.callback(event, context)
 		).resolves.toBeUndefined();
+		expect(coreOK.appendToDescription).toHaveBeenLastCalledWith('test', TextToAppend);
 		expect(coreOK.appendToDescription).toHaveBeenCalledTimes(1);
 	});
 	test('Append to description failure', async () => {
 		const context = new MockContext();
-		const event = makeEvent(ActionId.AppendToDescription, { broadcast_id: 'test', text: 'text to append' });
+		context.setVariable('hello:hello', 'BAD');
+
+		const TextToAppend = 'text to append';
+		const event = makeEvent(ActionId.AppendToDescription, {
+			broadcast_id_is_text: false,
+			broadcast_id: 'test',
+			broadcast_id_text: '$(hello:hello)',
+			text: TextToAppend,
+		});
 		await expect(
 			actionsKO.append_to_description.callback(event, context)
 		).rejects.toBeInstanceOf(Error);
+		expect(coreKO.appendToDescription).toHaveBeenLastCalledWith('test', TextToAppend);
 		expect(coreKO.appendToDescription).toHaveBeenCalledTimes(1);
 	});
 	test('Add chapter to description success', async () => {
 		const context = new MockContext();
+		context.setVariable('custom:separator', 'DO NOT USE');
+
 		const ChapterTitle = 'gooder chapter title';
 		const event = makeEvent(ActionId.AddChapterToDescription, {
+			broadcast_id_is_text: false,
 			broadcast_id: 'test',
+			broadcast_id_text: 'BAD',
 			title: ChapterTitle,
 			default_separator: true,
+			separator: '$(custom:separator)',
 		});
 		await expect(
 			actionsOK.add_chapter_to_description.callback(event, context)
@@ -378,11 +524,17 @@ describe('Action callback', () => {
 	});
 	test('Add chapter to description failure', async () => {
 		const context = new MockContext();
+		context.setVariable('sing:song', 'test');
+		context.setVariable('bad:bunny', 'DO NOT USE');
+
 		const ChapterTitle = 'goodest chapter title';
 		const event = makeEvent(ActionId.AddChapterToDescription, {
-			broadcast_id: 'test',
+			broadcast_id_is_text: true,
+			broadcast_id: 'BAD',
+			broadcast_id_text: '$(sing:song)',
 			title: ChapterTitle,
 			default_separator: true,
+			separator: '$(bad:bunny)',
 		});
 		await expect(
 			actionsKO.add_chapter_to_description.callback(event, context)
@@ -392,10 +544,14 @@ describe('Action callback', () => {
 	});
 	test('Add chapter with custom separator to description success', async () => {
 		const context = new MockContext();
+		context.setVariable('epoch:fail', 'BAD');
+
 		const ChapterTitle = 'quality chapter title';
 		const Sep = '—';
 		const event = makeEvent(ActionId.AddChapterToDescription, {
+			broadcast_id_is_text: false,
 			broadcast_id: 'test',
+			broadcast_id_text: '$(epoch:fail)',
 			title: ChapterTitle,
 			default_separator: false,
 			separator: Sep,
@@ -408,10 +564,14 @@ describe('Action callback', () => {
 	});
 	test('Add chapter with custom separator to description failure', async () => {
 		const context = new MockContext();
+		context.setVariable('brief:ly', 'test');
+
 		const ChapterTitle = 'A-OK chapter title';
 		const Sep = 'DASH';
 		const event = makeEvent(ActionId.AddChapterToDescription, {
-			broadcast_id: 'test',
+			broadcast_id_is_text: true,
+			broadcast_id: 'BAD',
+			broadcast_id_text: '$(brief:ly)',
 			title: ChapterTitle,
 			default_separator: false,
 			separator: Sep,

--- a/src/__tests__/actions.ts
+++ b/src/__tests__/actions.ts
@@ -145,7 +145,8 @@ describe('Action callback', () => {
 		const event = makeEvent(ActionId.InitBroadcast, {});
 		await expect(
 			actionsOK.init_broadcast.callback(event, context)
-		).rejects.toBeInstanceOf(Error);
+		).resolves.toBeUndefined();
+		expect(coreOK.Module.log).toHaveBeenLastCalledWith('warn', 'Action failed: undefined broadcast ID')
 		expect(coreOK.startBroadcastTest).toHaveBeenCalledTimes(0);
 	});
 	test('Unknown broadcast ID', async () => {
@@ -153,7 +154,11 @@ describe('Action callback', () => {
 		const event = makeEvent(ActionId.InitBroadcast, { broadcast_id: 'random' });
 		await expect(
 			actionsOK.init_broadcast.callback(event, context)
-		).rejects.toBeInstanceOf(Error);
+		).resolves.toBeUndefined();
+		expect(coreOK.Module.log).toHaveBeenLastCalledWith(
+			'warn',
+			"Action failed: broadcast ID 'random' - not found or invalid"
+		);
 		expect(coreOK.startBroadcastTest).toHaveBeenCalledTimes(0);
 	});
 

--- a/src/__tests__/feedbacks.ts
+++ b/src/__tests__/feedbacks.ts
@@ -15,6 +15,9 @@ import { MockContext } from '../__mocks__/context';
 //
 
 const SampleContext = new MockContext();
+SampleContext.setVariable('letter:e', 'e');
+SampleContext.setVariable('string:bad', 'BAD');
+SampleContext.setVariable('string:test', 'test');
 
 const SampleMemory: StateMemory = {
 	Broadcasts: {
@@ -49,7 +52,9 @@ const SampleBroadcastCheck: CompanionFeedbackAdvancedEvent = {
 		bg_testing: combineRgb(255, 255, 0),
 		bg_live: combineRgb(255, 0, 0),
 		bg_complete: combineRgb(0, 0, 255),
-		broadcast: 'test',
+		broadcast_id_is_text: false,
+		broadcast_id: 'test',
+		broadcast_id_text: '$(string:bad)',
 	},
 	_page: 0,
 	_bank: 0,
@@ -66,7 +71,9 @@ const SampleStreamCheck: CompanionFeedbackAdvancedEvent = {
 		bg_ok: combineRgb(255, 255, 0),
 		bg_bad: combineRgb(255, 0, 0),
 		bg_no_data: combineRgb(0, 0, 255),
-		broadcast: 'test',
+		broadcast_id_is_text: true,
+		broadcast_id: 'BAD',
+		broadcast_id_text: 't$(letter:e)st',
 	},
 	_page: 0,
 	_bank: 0,
@@ -183,7 +190,9 @@ describe('Broadcast lifecycle feedback', () => {
 			type: 'advanced',
 			feedbackId: 'broadcast_status',
 			options: {
-				broadcast: 'test',
+				broadcast_id_is_text: true,
+				broadcast_id: 'BAD',
+				broadcast_id_text: '$(string:test)',
 			},
 			_page: 0,
 			_bank: 0,
@@ -309,7 +318,9 @@ describe('Stream health feedback', () => {
 			type: 'advanced',
 			feedbackId: 'broadcast_bound_stream_health',
 			options: {
-				broadcast: 'test',
+				broadcast_id_is_text: false,
+				broadcast_id: 'test',
+				broadcast_id_text: '$(string:bad)',
 			},
 			_page: 0,
 			_bank: 0,

--- a/src/__tests__/feedbacks.ts
+++ b/src/__tests__/feedbacks.ts
@@ -194,7 +194,7 @@ describe('Broadcast lifecycle feedback', () => {
 		await core.init();
 
 		const feedbacks = listFeedbacks(() => ({ broadcasts: SampleMemory.Broadcasts, unfinishedCount: 0, core: core }));
-		const result = feedbacks.broadcast_status.callback(event, SampleContext);
+		const result = await feedbacks.broadcast_status.callback(event, SampleContext);
 
 		expect(result).toHaveProperty('bgcolor');
 		expect(result.bgcolor).not.toBe(0);
@@ -223,7 +223,7 @@ describe('Broadcast lifecycle feedback', () => {
 		core.Cache = data;
 
 		const feedbacks = listFeedbacks(() => ({ broadcasts: SampleMemory.Broadcasts, unfinishedCount: 0, core: core }));
-		const result = feedbacks.broadcast_status.callback(event, SampleContext);
+		const result = await feedbacks.broadcast_status.callback(event, SampleContext);
 
 		expect(Object.keys(result)).toHaveLength(0);
 	});
@@ -250,7 +250,7 @@ describe('Broadcast lifecycle feedback', () => {
 		core.Cache = data;
 
 		const feedbacks = listFeedbacks(() => ({ broadcasts: SampleMemory.Broadcasts, unfinishedCount: 0, core: core }));
-		const result = feedbacks.broadcast_status.callback(event, SampleContext);
+		const result = await feedbacks.broadcast_status.callback(event, SampleContext);
 
 		expect(Object.keys(result)).toHaveLength(0);
 	});
@@ -320,7 +320,7 @@ describe('Stream health feedback', () => {
 		await core.init();
 
 		const feedbacks = listFeedbacks(() => ({ broadcasts: SampleMemory.Broadcasts, unfinishedCount: 0, core: core }));
-		const result = feedbacks.broadcast_bound_stream_health.callback(event, SampleContext);
+		const result = await feedbacks.broadcast_bound_stream_health.callback(event, SampleContext);
 
 		expect(result).toHaveProperty('bgcolor');
 		expect(result.bgcolor).not.toBe(0);
@@ -349,7 +349,7 @@ describe('Stream health feedback', () => {
 		core.Cache = data;
 
 		const feedbacks = listFeedbacks(() => ({ broadcasts: SampleMemory.Broadcasts, unfinishedCount: 0, core: core }));
-		const result = feedbacks.broadcast_bound_stream_health.callback(event, SampleContext);
+		const result = await feedbacks.broadcast_bound_stream_health.callback(event, SampleContext);
 
 		expect(Object.keys(result)).toHaveLength(0);
 	});
@@ -395,7 +395,7 @@ describe('Stream health feedback', () => {
 		core.Cache = data;
 
 		const feedbacks = listFeedbacks(() => ({ broadcasts: SampleMemory.Broadcasts, unfinishedCount: 0, core: core }));
-		const result = feedbacks.broadcast_bound_stream_health.callback(event, SampleContext);
+		const result = await feedbacks.broadcast_bound_stream_health.callback(event, SampleContext);
 
 		expect(Object.keys(result)).toHaveLength(0);
 	});
@@ -422,7 +422,7 @@ describe('Stream health feedback', () => {
 		core.Cache = data;
 
 		const feedbacks = listFeedbacks(() => ({ broadcasts: SampleMemory.Broadcasts, unfinishedCount: 0, core: core }));
-		const result = feedbacks.broadcast_bound_stream_health.callback(event, SampleContext);
+		const result = await feedbacks.broadcast_bound_stream_health.callback(event, SampleContext);
 
 		expect(Object.keys(result)).toHaveLength(0);
 	});

--- a/src/common.ts
+++ b/src/common.ts
@@ -1,4 +1,13 @@
-import { CompanionActionContext, CompanionOptionValues, InstanceBase } from '@companion-module/base';
+import {
+	CompanionActionContext,
+	CompanionInputFieldCheckbox,
+	CompanionInputFieldDropdown,
+	CompanionInputFieldTextInput,
+	CompanionOptionValues,
+	DropdownChoice,
+	DropdownChoiceId,
+	InstanceBase,
+} from '@companion-module/base';
 import { BroadcastID } from './cache';
 import { YoutubeConfig } from './config';
 
@@ -47,16 +56,60 @@ export function sleep(ms: number): Promise<void> {
 	});
 }
 
-export const BroadcastIdOptionId = 'broadcast_id';
+export const BroadcastIdIsTextOptionId = 'broadcast_id_is_text';
+export const BroadcastIdDropdownOptionId = 'broadcast_id';
+export const BroadcastIdTextOptionId = 'broadcast_id_text';
+
+export const BroadcastIdIsTextCheckbox: CompanionInputFieldCheckbox = {
+	type: 'checkbox',
+	label: 'Specify broadcast ID from text',
+	id: BroadcastIdIsTextOptionId,
+	default: false,
+} as const;
+
+export function broadcastIdDropdownOption(
+	choices: DropdownChoice[],
+	defaultChoice: DropdownChoiceId
+): CompanionInputFieldDropdown {
+	return {
+		type: 'dropdown',
+		label: 'Broadcast:',
+		id: BroadcastIdDropdownOptionId,
+		choices,
+		default: defaultChoice,
+		// Hardcode the option name because isVisible functions must serialize
+		// to string and back.
+		isVisible: (options): boolean => !options.broadcast_id_is_text,
+	};
+}
+
+export const BroadcastIdFromTextOption: CompanionInputFieldTextInput = {
+	type: 'textinput',
+	label: 'Broadcast ID:',
+	id: BroadcastIdTextOptionId,
+	tooltip: 'YouTube broadcast ID, e.g. dQw4w9WgXcQ',
+	useVariables: true,
+	// Hardcode the option name because isVisible functions must serialize
+	// to string and back.
+	isVisible: (options) => !!options.broadcast_id_is_text,
+} as const;
 
 export async function getBroadcastIdFromOptions(
 	options: CompanionOptionValues,
-	_context: CompanionActionContext
+	context: CompanionActionContext
 ): Promise<BroadcastID | undefined> {
-	const rawBroadcastId = options[BroadcastIdOptionId];
-	if (rawBroadcastId) {
-		return String(rawBroadcastId);
+	const defineBroadcastIdFromText = Boolean(options[BroadcastIdIsTextOptionId]);
+	let broadcastId: BroadcastID;
+	if (defineBroadcastIdFromText) {
+		broadcastId = await context.parseVariablesInString(String(options[BroadcastIdTextOptionId]));
 	} else {
-		return undefined;
+		const rawBroadcastId = options[BroadcastIdDropdownOptionId];
+		if (rawBroadcastId) {
+			broadcastId = String(rawBroadcastId);
+		} else {
+			return undefined;
+		}
 	}
+
+	return broadcastId;
 }

--- a/src/common.ts
+++ b/src/common.ts
@@ -1,4 +1,5 @@
-import { InstanceBase } from '@companion-module/base'
+import { CompanionActionContext, CompanionOptionValues, InstanceBase } from '@companion-module/base';
+import { BroadcastID } from './cache';
 import { YoutubeConfig } from './config';
 
 /** Generic module skeleton for extracting function types. */
@@ -44,4 +45,18 @@ export function sleep(ms: number): Promise<void> {
 	return new Promise((resolve) => {
 		setTimeout(resolve, ms);
 	});
+}
+
+export const BroadcastIdOptionId = 'broadcast_id';
+
+export async function getBroadcastIdFromOptions(
+	options: CompanionOptionValues,
+	_context: CompanionActionContext
+): Promise<BroadcastID | undefined> {
+	const rawBroadcastId = options[BroadcastIdOptionId];
+	if (rawBroadcastId) {
+		return String(rawBroadcastId);
+	} else {
+		return undefined;
+	}
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ import { getBroadcastVars, exportVars, declareVars, getUnfinishedBroadcastStateV
 import { listActions } from './actions';
 import { listFeedbacks } from './feedbacks';
 import { listPresets } from './presets';
+import { UpgradeScripts } from './upgrades';
 import { YoutubeConnector } from './youtube';
 import { YoutubeAuthorization, AuthorizationEnvironment } from './auth/mainFlow';
 
@@ -170,4 +171,4 @@ export class YoutubeInstance extends InstanceBase<YoutubeConfig> implements Modu
 	}
 }
 
-runEntrypoint(YoutubeInstance, []);
+runEntrypoint(YoutubeInstance, UpgradeScripts);

--- a/src/upgrades.ts
+++ b/src/upgrades.ts
@@ -1,5 +1,6 @@
 import type {
 	CompanionMigrationAction,
+	CompanionMigrationFeedback,
 	CompanionStaticUpgradeProps,
 	CompanionStaticUpgradeResult,
 	CompanionStaticUpgradeScript,
@@ -7,6 +8,7 @@ import type {
 } from '@companion-module/base';
 import { tryUpgradeActionSelectingBroadcastId } from './actions';
 import type { YoutubeConfig } from './config';
+import { tryUpgradeFeedbackSelectingBroadcastID } from './feedbacks';
 
 function ActionUpdater(
 	tryUpdate: (action: CompanionMigrationAction) => boolean
@@ -23,7 +25,23 @@ function ActionUpdater(
 	};
 }
 
+function FeedbackUpdater(
+	tryUpdate: (feedback: CompanionMigrationFeedback) => boolean
+): CompanionStaticUpgradeScript<YoutubeConfig> {
+	return (
+		_context: CompanionUpgradeContext<YoutubeConfig>,
+		props: CompanionStaticUpgradeProps<YoutubeConfig>
+	): CompanionStaticUpgradeResult<YoutubeConfig> => {
+		return {
+			updatedActions: [],
+			updatedConfig: null,
+			updatedFeedbacks: props.feedbacks.filter(tryUpdate),
+		};
+	};
+}
+
 export const UpgradeScripts = [
 	// force separate upgrade scripts onto separate lines
 	ActionUpdater(tryUpgradeActionSelectingBroadcastId),
+	FeedbackUpdater(tryUpgradeFeedbackSelectingBroadcastID),
 ] satisfies CompanionStaticUpgradeScript<YoutubeConfig>[];

--- a/src/upgrades.ts
+++ b/src/upgrades.ts
@@ -1,0 +1,29 @@
+import type {
+	CompanionMigrationAction,
+	CompanionStaticUpgradeProps,
+	CompanionStaticUpgradeResult,
+	CompanionStaticUpgradeScript,
+	CompanionUpgradeContext,
+} from '@companion-module/base';
+import { tryUpgradeActionSelectingBroadcastId } from './actions';
+import type { YoutubeConfig } from './config';
+
+function ActionUpdater(
+	tryUpdate: (action: CompanionMigrationAction) => boolean
+): CompanionStaticUpgradeScript<YoutubeConfig> {
+	return (
+		_context: CompanionUpgradeContext<YoutubeConfig>,
+		props: CompanionStaticUpgradeProps<YoutubeConfig>
+	): CompanionStaticUpgradeResult<YoutubeConfig> => {
+		return {
+			updatedActions: props.actions.filter(tryUpdate),
+			updatedConfig: null,
+			updatedFeedbacks: [],
+		};
+	};
+}
+
+export const UpgradeScripts = [
+	// force separate upgrade scripts onto separate lines
+	ActionUpdater(tryUpgradeActionSelectingBroadcastId),
+] satisfies CompanionStaticUpgradeScript<YoutubeConfig>[];


### PR DESCRIPTION
Existing actions/feedbacks for manipulating/observing YouTube broadcast/stream status require you to manually select the broadcast to act upon, from a list queried from YouTube itself by an action that refreshes the list (or just at connection startup).  Thus use Companion with YouTube, users _have to_ interact with Companion software directly, to manually select the broadcasts they want to act upon in those actions.

#109 is already on file asking for a way to programmatically specify the broadcast to act upon.  This PR implements that issue's request.

I've replaced all broadcast selection dropdown options with a set of three options: 1) a checkbox to determine whether to use 2) the existing dropdown list option or 3) a new textinput option to specify the broadcast ID manually.  The textinput supports variables -- so a user can use, say, `$(YT:unfinished_$(custom:broadcast_selector)_id)` to specify the broadcast ID of an unfinished (or for some actions, finished) broadcast.

I've split this up a tad:

* The first commit simply specifies a yarn version, because just running `yarn` in the repo as-is starts mucking with `package.json`.  I also had to update `@companion-module/tools` because it was assuming it was working under classic yarn (I think), and the Github workflow that verifies the module can be packaged was failing.
* The second commit rejiggers a bunch of the actions code to compute the desired broadcast ID consistently using a helper function.  The helper function's API anticipates variable-parsing, so it's async and takes an unused context argument.  I also did some slight cleanups away from type casts to using action conversion functions.
* The third commit splits the one broadcast ID dropdown option in actions into a checkbox, a dropdown, and a textinput -- with latter two visible dependent upon checkbox state.  It also adds an upgrade script to add the checkbox and textinput option values to existing actions.
* The fourth commit adds a similar helper function to feedbacks code, to compute the broadcast from options.
* And the fifth commit performs the same option split, but for feedbacks (and with upgrade script support).

I did some meager testing of this, and at least one action and both feedbacks seem to work.  (I only tested one action because they're all using the same helper function support.)

The module code is so far from `yarn lint`-clean that to a vague approximation I just ignored cleanliness.  It probably would be worth adding a workflow that requires lint-cleanness if that's something the module cares about, because otherwise it's unclear with patches like this whether to clean up first, clean up after, or something else entirely.