### PR TITLE
feat: Add broadcast creation, stream binding, and thumbnail actions

### DIFF
--- a/companion/HELP.md
+++ b/companion/HELP.md
@@ -8,9 +8,7 @@ broadcasts that the action might be performed upon, or by specifying its ID (the
 part after the `?v=...` in a YouTube video URL) as textual input. A checkbox
 switches between the two modes.
 
-The module currently only allows already-created broadcasts to be manipulated:
-it doesn't offer a way to create them itself. You'll have to create a broadcast
-in YouTube Studio in order to be able to manipulate it.
+The module can create new broadcasts and manipulate existing ones.
 
 ## Available actions
 
@@ -47,6 +45,18 @@ in YouTube Studio in order to be able to manipulate it.
   the description.
 - **Add chapter timecode to description** - This action inserts a chapter
   timecode at the end of the description.
+- **Create new broadcast** - This action creates a new YouTube broadcast with
+  the specified settings. Supports using an existing broadcast as a template to
+  copy settings from (title, description, monitor stream, and stream binding).
+  Options include scheduled start time (now, minutes from now, or custom ISO
+  8601), privacy status, auto-start/auto-stop, thumbnail upload, and stream
+  binding.
+- **Set broadcast thumbnail** - This action uploads and sets a custom thumbnail
+  image for a broadcast. Accepts a local file path or URL to a JPEG/PNG image
+  (max 2MB).
+- **Bind stream to broadcast** - This action binds a video stream to a
+  broadcast, which is required before going live. Select a stream from the
+  dropdown or enter a stream ID manually.
 
 [ytapi]: https://developers.google.com/youtube/v3/live/docs/liveBroadcasts/transition
 
@@ -165,6 +175,34 @@ completing the consent process can be found underneath that link.
 Consent while in "Testing" status only lasts a week. After that you'll have to
 reopen the consent screen and recomplete the consent process.
 
+## Available feedbacks
+
+- **Broadcast status** - Changes button colors based on the broadcast lifecycle
+  state (ready, testing, live, complete). Colors are configurable.
+- **Health of stream bound to broadcast** - Changes button colors based on the
+  health of the video stream bound to a broadcast (good, ok, bad, no data).
+
+## Available variables
+
+Per-broadcast variables (where `ID` is the YouTube broadcast ID):
+
+- `broadcast_ID_lifecycle` - Lifecycle state of the broadcast
+- `broadcast_ID_health` - Health of the stream bound to the broadcast
+
+Unfinished broadcast variables (where `N` is the index, starting from 0):
+
+- `unfinished_N` - Name of unfinished broadcast #N
+- `unfinished_N_id` - ID of unfinished broadcast #N
+- `unfinished_short_N` - Shortened name of unfinished broadcast #N
+- `unfinished_state_N` - State of unfinished broadcast #N
+- `unfinished_health_N` - Stream health of unfinished broadcast #N
+- `unfinished_concurrent_viewers_N` - Concurrent viewers of unfinished broadcast #N
+
+Global variables:
+
+- `last_created_broadcast_id` - ID of the most recently created broadcast (via
+  the "Create new broadcast" action)
+
 ## Action configuration
 
 When creating actions to operate upon a broadcast, pick the broadcast to work
@@ -178,6 +216,21 @@ Alternatively, if you have the YouTube broadcast ID, you can check the checkbox
 to switch to a text input and enter it there. The text field supports
 variables, so you can also store the broadcast ID in a variable and change that
 variable as needed.
+
+### Using templates with Create broadcast
+
+When creating a broadcast, you can check "Use existing broadcast as template" to
+copy settings from an existing broadcast. Template values serve as defaults:
+any value you explicitly set will override the template. This is useful for
+creating broadcasts with consistent settings. The template's description,
+monitor stream setting, and stream binding will be copied if you don't provide
+your own.
+
+### Using the last created broadcast ID
+
+After creating a broadcast, its ID is stored in the `last_created_broadcast_id`
+variable. You can use this variable in subsequent actions (via text input mode)
+to operate on the newly created broadcast without knowing its ID in advance.
 
 ## Thanks
 

--- a/companion/HELP.md
+++ b/companion/HELP.md
@@ -188,6 +188,7 @@ Per-broadcast variables (where `ID` is the YouTube broadcast ID):
 
 - `broadcast_ID_lifecycle` - Lifecycle state of the broadcast
 - `broadcast_ID_health` - Health of the stream bound to the broadcast
+- `broadcast_ID_visibility` - Visibility (public/private/unlisted) of the broadcast
 
 Unfinished broadcast variables (where `N` is the index, starting from 0):
 
@@ -197,6 +198,7 @@ Unfinished broadcast variables (where `N` is the index, starting from 0):
 - `unfinished_state_N` - State of unfinished broadcast #N
 - `unfinished_health_N` - Stream health of unfinished broadcast #N
 - `unfinished_concurrent_viewers_N` - Concurrent viewers of unfinished broadcast #N
+- `unfinished_visibility_N` - Visibility (public/private/unlisted) of the broadcast
 
 Global variables:
 

--- a/companion/HELP.md
+++ b/companion/HELP.md
@@ -52,8 +52,8 @@ The module can create new broadcasts and manipulate existing ones.
   8601), privacy status, auto-start/auto-stop, thumbnail upload, and stream
   binding.
 - **Set broadcast thumbnail** - This action uploads and sets a custom thumbnail
-  image for a broadcast. Accepts a local file path or URL to a JPEG/PNG image
-  (max 2MB).
+  image for a broadcast. Accepts a local file path to a JPEG/PNG image (max
+  2MB).
 - **Bind stream to broadcast** - This action binds a video stream to a
   broadcast, which is required before going live. Select a stream from the
   dropdown or enter a stream ID manually.

--- a/src/__tests__/mock/fake-youtube.ts
+++ b/src/__tests__/mock/fake-youtube.ts
@@ -33,5 +33,10 @@ export class FakeYouTube {
 		insertCuepoint:
 			vi.fn<LiveBroadcastsMethod<'insertCuepoint', [youtube_v3.Params$Resource$Livebroadcasts$Insertcuepoint]>>(),
 		update: vi.fn<LiveBroadcastsMethod<'update', [youtube_v3.Params$Resource$Livebroadcasts$Update]>>(),
+		insert: vi.fn(),
+		bind: vi.fn(),
+	};
+	thumbnails = {
+		set: vi.fn(),
 	};
 }

--- a/src/__tests__/mock/fake-youtube.ts
+++ b/src/__tests__/mock/fake-youtube.ts
@@ -23,6 +23,10 @@ type LiveBroadcastsMethod<Func extends keyof LiveBroadcasts, Params extends any[
 	Params
 >;
 
+type Thumbnails = youtube_v3.Youtube['thumbnails'];
+
+type ThumbnailsMethod<Func extends keyof Thumbnails, Params extends any[]> = APIMethod<Thumbnails, Func, Params>;
+
 export class FakeYouTube {
 	liveStreams = {
 		list: vi.fn<LiveStreamsMethod<'list', [youtube_v3.Params$Resource$Livestreams$List]>>(),
@@ -33,10 +37,10 @@ export class FakeYouTube {
 		insertCuepoint:
 			vi.fn<LiveBroadcastsMethod<'insertCuepoint', [youtube_v3.Params$Resource$Livebroadcasts$Insertcuepoint]>>(),
 		update: vi.fn<LiveBroadcastsMethod<'update', [youtube_v3.Params$Resource$Livebroadcasts$Update]>>(),
-		insert: vi.fn(),
-		bind: vi.fn(),
+		insert: vi.fn<LiveBroadcastsMethod<'insert', [youtube_v3.Params$Resource$Livebroadcasts$Insert]>>(),
+		bind: vi.fn<LiveBroadcastsMethod<'bind', [youtube_v3.Params$Resource$Livebroadcasts$Bind]>>(),
 	};
 	thumbnails = {
-		set: vi.fn(),
+		set: vi.fn<ThumbnailsMethod<'set', [youtube_v3.Params$Resource$Thumbnails$Set]>>(),
 	};
 }

--- a/src/__tests__/mock/youtube-api.ts
+++ b/src/__tests__/mock/youtube-api.ts
@@ -34,5 +34,17 @@ export function makeMockYT(memory: StateMemory): YoutubeAPI {
 		setVisibility: vi.fn<YoutubeAPI['setVisibility']>().mockImplementation(async () => {
 			return Promise.resolve();
 		}),
+		createBroadcast: vi.fn<YoutubeAPI['createBroadcast']>().mockImplementation(async () => {
+			return Promise.resolve('newBroadcastId');
+		}),
+		setThumbnail: vi.fn<YoutubeAPI['setThumbnail']>().mockImplementation(async () => {
+			return Promise.resolve();
+		}),
+		listStreams: vi.fn<YoutubeAPI['listStreams']>().mockImplementation(async () => {
+			return Promise.resolve(memory.Streams);
+		}),
+		bindBroadcastToStream: vi.fn<YoutubeAPI['bindBroadcastToStream']>().mockImplementation(async () => {
+			return Promise.resolve();
+		}),
 	};
 }

--- a/src/actions.test.ts
+++ b/src/actions.test.ts
@@ -28,7 +28,9 @@ const SampleMemory: StateMemory = {
 		},
 	},
 	Streams: {},
+	BoundStreams: {},
 	UnfinishedBroadcasts: [],
+	LastCreatedBroadcast: null,
 };
 
 //
@@ -37,7 +39,7 @@ const SampleMemory: StateMemory = {
 
 describe('Action list', () => {
 	test('Module has required actions', () => {
-		const result = listActions({ broadcasts: SampleMemory.Broadcasts, unfinishedCount: 3, core: null });
+		const result = listActions({ broadcasts: SampleMemory.Broadcasts, unfinishedCount: 3, core: null, streams: {} });
 		expect(result).toHaveProperty(ActionId.InitBroadcast);
 		expect(result).toHaveProperty(ActionId.StartBroadcast);
 		expect(result).toHaveProperty(ActionId.StopBroadcast);
@@ -115,8 +117,8 @@ describe('Action callback', () => {
 	void coreKO.init();
 
 	// List actions
-	const actionsOK = listActions({ broadcasts: SampleMemory.Broadcasts, unfinishedCount: 0, core: coreOK });
-	const actionsKO = listActions({ broadcasts: SampleMemory.Broadcasts, unfinishedCount: 0, core: coreKO });
+	const actionsOK = listActions({ broadcasts: SampleMemory.Broadcasts, unfinishedCount: 0, core: coreOK, streams: {} });
+	const actionsKO = listActions({ broadcasts: SampleMemory.Broadcasts, unfinishedCount: 0, core: coreKO, streams: {} });
 
 	// Make event
 	function makeEvent(actionId: string, options: CompanionOptionValues): CompanionActionEvent {

--- a/src/actions.test.ts
+++ b/src/actions.test.ts
@@ -31,7 +31,9 @@ const SampleMemory: StateMemory = {
 		},
 	},
 	Streams: {},
+	BoundStreams: {},
 	UnfinishedBroadcasts: [],
+	LastCreatedBroadcast: null,
 };
 
 //
@@ -40,7 +42,7 @@ const SampleMemory: StateMemory = {
 
 describe('Action list', () => {
 	test('Module has required actions', () => {
-		const result = listActions({ broadcasts: SampleMemory.Broadcasts, unfinishedCount: 3, core: null });
+		const result = listActions({ broadcasts: SampleMemory.Broadcasts, unfinishedCount: 3, core: null, streams: {} });
 		expect(result).toHaveProperty(ActionId.InitBroadcast);
 		expect(result).toHaveProperty(ActionId.StartBroadcast);
 		expect(result).toHaveProperty(ActionId.StopBroadcast);
@@ -118,8 +120,8 @@ describe('Action callback', () => {
 	void coreKO.init();
 
 	// List actions
-	const actionsOK = listActions({ broadcasts: SampleMemory.Broadcasts, unfinishedCount: 0, core: coreOK });
-	const actionsKO = listActions({ broadcasts: SampleMemory.Broadcasts, unfinishedCount: 0, core: coreKO });
+	const actionsOK = listActions({ broadcasts: SampleMemory.Broadcasts, unfinishedCount: 0, core: coreOK, streams: {} });
+	const actionsKO = listActions({ broadcasts: SampleMemory.Broadcasts, unfinishedCount: 0, core: coreKO, streams: {} });
 
 	// Make event
 	function makeEvent(actionId: string, options: CompanionOptionValues): CompanionActionEvent {

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -568,13 +568,13 @@ export function listActions({
 					isVisibleExpression: '!!$(options:bind_stream) && !!$(options:stream_id_is_text)',
 				},
 			],
-			callback: async (event): Promise<void> => {
+			callback: async ({ options }): Promise<void> => {
 				if (!core) {
 					throw new Error('Module core is not initialized');
 				}
 
-				const title = String(event.options.title || '');
-				const useTemplate = !!event.options.use_template;
+				const title = String(options.title || '');
+				const useTemplate = !!options.use_template;
 				if (!useTemplate && (!title || title.length === 0)) {
 					throw new Error('Title is required when not using a template');
 				}
@@ -583,12 +583,12 @@ export function listActions({
 				}
 
 				let scheduledStartTime: string;
-				switch (event.options.start_time_type) {
+				switch (options.start_time_type) {
 					case 'now':
 						scheduledStartTime = new Date().toISOString();
 						break;
 					case 'minutes': {
-						const minutesStr = String(event.options.minutes_from_now || '5');
+						const minutesStr = String(options.minutes_from_now || '5');
 						const minutes = parseInt(minutesStr, 10);
 						if (isNaN(minutes) || minutes < 0) {
 							throw new Error('Invalid minutes value');
@@ -597,7 +597,7 @@ export function listActions({
 						break;
 					}
 					case 'custom':
-						scheduledStartTime = String(event.options.custom_start_time || '');
+						scheduledStartTime = String(options.custom_start_time || '');
 						if (!scheduledStartTime) {
 							throw new Error('Custom start time is required');
 						}
@@ -606,7 +606,7 @@ export function listActions({
 						scheduledStartTime = new Date().toISOString();
 				}
 
-				const privacyStr = String(event.options.privacy || '');
+				const privacyStr = String(options.privacy || '');
 				let privacy: Visibility;
 				if (privacyStr) {
 					const lowerPrivacy = privacyStr.toLowerCase();
@@ -619,21 +619,21 @@ export function listActions({
 					privacy = Visibility.Private;
 				}
 
-				const description = String(event.options.description || '');
+				const description = String(options.description || '');
 
 				let autoStart: boolean | undefined;
 				let autoStop: boolean | undefined;
-				if (event.options.auto_start === 'yes') autoStart = true;
-				else if (event.options.auto_start === 'no') autoStart = false;
-				if (event.options.auto_stop === 'yes') autoStop = true;
-				else if (event.options.auto_stop === 'no') autoStop = false;
+				if (options.auto_start === 'yes') autoStart = true;
+				else if (options.auto_start === 'no') autoStart = false;
+				if (options.auto_stop === 'yes') autoStop = true;
+				else if (options.auto_stop === 'no') autoStop = false;
 
 				let templateId: BroadcastID | undefined;
-				if (event.options.use_template) {
-					if (event.options.template_id_is_text) {
-						templateId = String(event.options.template_id_text || '');
+				if (options.use_template) {
+					if (options.template_id_is_text) {
+						templateId = String(options.template_id_text || '');
 					} else {
-						templateId = String(event.options.template_id || '');
+						templateId = String(options.template_id || '');
 					}
 					if (templateId && templateId.startsWith('unfinished_')) {
 						const hit = core.Cache.UnfinishedBroadcasts.find((_a, i) => `unfinished_${i}` === templateId);
@@ -643,14 +643,14 @@ export function listActions({
 					}
 				}
 
-				const thumbnailPath = String(event.options.thumbnail_path || '');
+				const thumbnailPath = String(options.thumbnail_path || '');
 
 				let streamId: string | undefined;
-				if (event.options.bind_stream) {
-					if (event.options.stream_id_is_text) {
-						streamId = String(event.options.stream_id_text || '');
+				if (options.bind_stream) {
+					if (options.stream_id_is_text) {
+						streamId = String(options.stream_id_text || '');
 					} else {
-						streamId = String(event.options.stream_id || '');
+						streamId = String(options.stream_id || '');
 					}
 				}
 
@@ -681,8 +681,8 @@ export function listActions({
 					useVariables: { local: true },
 				},
 			],
-			callback: broadcastCallback(async (core, broadcastId, event) => {
-				const imagePath = String(event.options.image_path || '');
+			callback: broadcastCallback(async (core, broadcastId, { options }) => {
+				const imagePath = String(options.image_path || '');
 				if (!imagePath) {
 					throw new Error('Image path is required');
 				}
@@ -718,12 +718,12 @@ export function listActions({
 					isVisibleExpression: '!!$(options:stream_id_is_text)',
 				},
 			],
-			callback: broadcastCallback(async (core, broadcastId, event) => {
+			callback: broadcastCallback(async (core, broadcastId, { options }) => {
 				let streamId: string;
-				if (event.options.stream_id_is_text) {
-					streamId = String(event.options.stream_id_text || '');
+				if (options.stream_id_is_text) {
+					streamId = String(options.stream_id_text || '');
 				} else {
-					streamId = String(event.options.stream_id || '');
+					streamId = String(options.stream_id || '');
 				}
 
 				if (!streamId) {

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -454,7 +454,7 @@ export function listActions({
 					type: 'textinput',
 					label: 'Template ID:',
 					id: 'template_id_text',
-					useVariables: true,
+					useVariables: { local: true },
 					isVisibleExpression: '!!$(options:use_template) && !!$(options:template_id_is_text)',
 				},
 				{
@@ -463,14 +463,14 @@ export function listActions({
 					id: 'title',
 					regex: '/^.{0,100}$/',
 					description: 'Max 100 characters. Leave empty to use template title.',
-					useVariables: true,
+					useVariables: { local: true },
 				},
 				{
 					type: 'textinput',
 					label: 'Description:',
 					id: 'description',
 					description: 'Max 5000 characters. Leave empty to use template.',
-					useVariables: true,
+					useVariables: { local: true },
 					multiline: true,
 				},
 				{
@@ -478,7 +478,7 @@ export function listActions({
 					label: 'Thumbnail:',
 					id: 'thumbnail_path',
 					description: 'Local file path or URL to JPEG/PNG image (max 2MB)',
-					useVariables: true,
+					useVariables: { local: true },
 				},
 				{
 					type: 'textinput',
@@ -486,7 +486,7 @@ export function listActions({
 					id: 'privacy',
 					default: 'private',
 					description: 'private, unlisted, or public. Leave empty to use template.',
-					useVariables: true,
+					useVariables: { local: true },
 				},
 				{
 					type: 'dropdown',
@@ -504,7 +504,7 @@ export function listActions({
 					label: 'Minutes from now:',
 					id: 'minutes_from_now',
 					default: '5',
-					useVariables: true,
+					useVariables: { local: true },
 					isVisibleExpression: "$(options:start_time_type) === 'minutes'",
 				},
 				{
@@ -513,7 +513,7 @@ export function listActions({
 					id: 'custom_start_time',
 					tooltip: 'e.g. 2024-12-31T23:59:00Z',
 					description: 'Format: YYYY-MM-DDTHH:MM:SSZ (UTC timezone)',
-					useVariables: true,
+					useVariables: { local: true },
 					isVisibleExpression: "$(options:start_time_type) === 'custom'",
 				},
 				{
@@ -564,7 +564,7 @@ export function listActions({
 					label: 'Stream ID:',
 					id: 'stream_id_text',
 					description: 'Found in YouTube Studio > Go Live > Stream Settings',
-					useVariables: true,
+					useVariables: { local: true },
 					isVisibleExpression: '!!$(options:bind_stream) && !!$(options:stream_id_is_text)',
 				},
 			],
@@ -678,7 +678,7 @@ export function listActions({
 					id: 'image_path',
 					required: true,
 					description: 'Local file path or URL to JPEG/PNG image (max 2MB)',
-					useVariables: true,
+					useVariables: { local: true },
 				},
 			],
 			callback: broadcastCallback(async (core, broadcastId, event) => {
@@ -714,7 +714,7 @@ export function listActions({
 					label: 'Stream ID:',
 					id: 'stream_id_text',
 					description: 'Found in YouTube Studio > Go Live > Stream Settings',
-					useVariables: true,
+					useVariables: { local: true },
 					isVisibleExpression: '!!$(options:stream_id_is_text)',
 				},
 			],

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -569,9 +569,7 @@ export function listActions({
 				},
 			],
 			callback: async ({ options }): Promise<void> => {
-				if (!core) {
-					throw new Error('Module core is not initialized');
-				}
+				if (!core) noModuleCore();
 
 				const title = String(options.title || '');
 				const useTemplate = !!options.use_template;

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -52,8 +52,6 @@ export function tryUpgradeActionSelectingBroadcastId(action: CompanionMigrationA
 		case ActionId.PrependToDescription as string:
 		case ActionId.AppendToDescription as string:
 		case ActionId.AddChapterToDescription as string:
-		case ActionId.SetThumbnail as string:
-		case ActionId.BindStream as string:
 			options = action.options;
 			if (BroadcastIdIsTextOptionId in options) {
 				return false;

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -658,17 +658,17 @@ export function listActions({
 					}
 				}
 
-				await core.createBroadcast(
+				await core.createBroadcast({
 					title,
 					scheduledStartTime,
-					privacy,
-					description || undefined,
-					autoStart,
-					autoStop,
-					templateId || undefined,
-					thumbnailPath || undefined,
-					streamId || undefined
-				);
+					privacyStatus: privacy,
+					description: description || undefined,
+					enableAutoStart: autoStart,
+					enableAutoStop: autoStop,
+					templateId: templateId || undefined,
+					thumbnailPath: thumbnailPath || undefined,
+					streamId: streamId || undefined,
+				});
 			},
 		},
 		[ActionId.SetThumbnail]: {

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -4,7 +4,7 @@ import type {
 	CompanionMigrationAction,
 	DropdownChoice,
 } from '@companion-module/base';
-import { type BroadcastMap, youngerThan } from './cache.js';
+import { type BroadcastMap, type StreamMap, youngerThan } from './cache.js';
 import { BroadcastLifecycle } from './lifecycle.js';
 import { type BroadcastID, Visibility } from './types.js';
 import {
@@ -32,6 +32,9 @@ export enum ActionId {
 	AppendToDescription = 'append_to_description',
 	AddChapterToDescription = 'add_chapter_to_description',
 	SetVisibility = 'set_visibility',
+	CreateBroadcast = 'create_broadcast',
+	SetThumbnail = 'set_thumbnail',
+	BindStream = 'bind_stream',
 }
 
 export function tryUpgradeActionSelectingBroadcastId(action: CompanionMigrationAction): boolean {
@@ -49,6 +52,8 @@ export function tryUpgradeActionSelectingBroadcastId(action: CompanionMigrationA
 		case ActionId.PrependToDescription as string:
 		case ActionId.AppendToDescription as string:
 		case ActionId.AddChapterToDescription as string:
+		case ActionId.SetThumbnail as string:
+		case ActionId.BindStream as string:
 			options = action.options;
 			if (BroadcastIdIsTextOptionId in options) {
 				return false;
@@ -76,10 +81,12 @@ export function listActions({
 	broadcasts,
 	unfinishedCount,
 	core,
+	streams,
 }: {
 	broadcasts: BroadcastMap;
 	unfinishedCount: number;
 	core: Core | null;
+	streams: StreamMap;
 }): Record<ActionId, CompanionActionDefinition> {
 	const noModuleCore: () => never = () => {
 		throw new Error('Error: module core undefined.');
@@ -142,6 +149,15 @@ export function listActions({
 		unfinishedCount,
 		youngerThan(BroadcastLifecycle.Complete)
 	);
+
+	const streamEntries: DropdownChoice[] = Object.values(streams).map(
+		(item): DropdownChoice => ({
+			id: item.Id,
+			label: item.Name ? `${item.Name} (${item.Id})` : item.Id,
+		})
+	);
+
+	const defaultStream = streamEntries.length === 0 ? '' : streamEntries[0].id;
 
 	return {
 		[ActionId.InitBroadcast]: {
@@ -265,6 +281,7 @@ export function listActions({
 					regex: '/^.{0,5000}$/',
 					tooltip: 'Seize a description with a maximum length of 5000 characters',
 					useVariables: true,
+					multiline: true,
 				},
 			],
 			callback: broadcastCallback(async (core, broadcastId, event) => {
@@ -288,6 +305,7 @@ export function listActions({
 					regex: '/^.{1,5000}$/',
 					tooltip: 'The total length of the description must not exceed 5000 characters.',
 					useVariables: true,
+					multiline: true,
 				},
 			],
 			callback: broadcastCallback(async (core, broadcastId, event) => {
@@ -315,6 +333,7 @@ export function listActions({
 					regex: '/^.{1,5000}$/',
 					tooltip: 'The total length of the description must not exceed 5000 characters.',
 					useVariables: true,
+					multiline: true,
 				},
 			],
 			callback: broadcastCallback(async (core, broadcastId, event) => {
@@ -398,6 +417,324 @@ export function listActions({
 				}
 
 				return core.setVisibility(broadcastId, visibility);
+			}),
+		},
+		[ActionId.CreateBroadcast]: {
+			name: 'Create new broadcast',
+			description: 'Creates a new YouTube broadcast with the specified settings.',
+			options: [
+				{
+					type: 'checkbox',
+					label: 'Use existing broadcast as template?',
+					id: 'use_template',
+					default: false,
+				},
+				{
+					type: 'checkbox',
+					label: 'Specify template ID from text',
+					id: 'template_id_is_text',
+					default: false,
+					isVisibleExpression: '!!$(options:use_template)',
+				},
+				{
+					type: 'dropdown',
+					label: 'Template broadcast:',
+					id: 'template_id',
+					choices: [
+						...Object.values(broadcasts).map((item): DropdownChoice => ({ id: item.Id, label: item.Name })),
+						...[...Array(unfinishedCount).keys()].map(
+							(i): DropdownChoice => ({ id: `unfinished_${i}`, label: `Unfinished/planned #${i}` })
+						),
+					],
+					default:
+						Object.values(broadcasts).length > 0
+							? Object.values(broadcasts)[0].Id
+							: unfinishedCount > 0
+								? 'unfinished_0'
+								: '',
+					isVisibleExpression: '!!$(options:use_template) && !$(options:template_id_is_text)',
+				},
+				{
+					type: 'textinput',
+					label: 'Template ID:',
+					id: 'template_id_text',
+					useVariables: true,
+					isVisibleExpression: '!!$(options:use_template) && !!$(options:template_id_is_text)',
+				},
+				{
+					type: 'textinput',
+					label: 'Title:',
+					id: 'title',
+					regex: '/^.{0,100}$/',
+					description: 'Max 100 characters. Leave empty to use template title.',
+					useVariables: true,
+				},
+				{
+					type: 'textinput',
+					label: 'Description:',
+					id: 'description',
+					description: 'Max 5000 characters. Leave empty to use template.',
+					useVariables: true,
+					multiline: true,
+				},
+				{
+					type: 'textinput',
+					label: 'Thumbnail:',
+					id: 'thumbnail_path',
+					description: 'Local file path or URL to JPEG/PNG image (max 2MB)',
+					useVariables: true,
+				},
+				{
+					type: 'textinput',
+					label: 'Privacy:',
+					id: 'privacy',
+					default: 'private',
+					description: 'private, unlisted, or public. Leave empty to use template.',
+					useVariables: true,
+				},
+				{
+					type: 'dropdown',
+					label: 'Start time type:',
+					id: 'start_time_type',
+					choices: [
+						{ id: 'now', label: 'Now' },
+						{ id: 'minutes', label: 'Minutes from now' },
+						{ id: 'custom', label: 'Custom (ISO 8601)' },
+					],
+					default: 'now',
+				},
+				{
+					type: 'textinput',
+					label: 'Minutes from now:',
+					id: 'minutes_from_now',
+					default: '5',
+					useVariables: true,
+					isVisibleExpression: "$(options:start_time_type) === 'minutes'",
+				},
+				{
+					type: 'textinput',
+					label: 'Custom start time (ISO 8601):',
+					id: 'custom_start_time',
+					tooltip: 'e.g. 2024-12-31T23:59:00Z',
+					description: 'Format: YYYY-MM-DDTHH:MM:SSZ (UTC timezone)',
+					useVariables: true,
+					isVisibleExpression: "$(options:start_time_type) === 'custom'",
+				},
+				{
+					type: 'dropdown',
+					label: 'Auto-start:',
+					id: 'auto_start',
+					choices: [
+						{ id: 'no', label: 'No' },
+						{ id: 'yes', label: 'Yes' },
+						{ id: 'template', label: 'Use template' },
+					],
+					default: 'no',
+				},
+				{
+					type: 'dropdown',
+					label: 'Auto-stop:',
+					id: 'auto_stop',
+					choices: [
+						{ id: 'no', label: 'No' },
+						{ id: 'yes', label: 'Yes' },
+						{ id: 'template', label: 'Use template' },
+					],
+					default: 'no',
+				},
+				{
+					type: 'checkbox',
+					label: 'Bind to stream?',
+					id: 'bind_stream',
+					default: false,
+				},
+				{
+					type: 'checkbox',
+					label: 'Specify stream ID from text',
+					id: 'stream_id_is_text',
+					default: false,
+					isVisibleExpression: '!!$(options:bind_stream)',
+				},
+				{
+					type: 'dropdown',
+					label: 'Stream:',
+					id: 'stream_id',
+					choices: streamEntries,
+					default: defaultStream,
+					isVisibleExpression: '!!$(options:bind_stream) && !$(options:stream_id_is_text)',
+				},
+				{
+					type: 'textinput',
+					label: 'Stream ID:',
+					id: 'stream_id_text',
+					description: 'Found in YouTube Studio > Go Live > Stream Settings',
+					useVariables: true,
+					isVisibleExpression: '!!$(options:bind_stream) && !!$(options:stream_id_is_text)',
+				},
+			],
+			callback: async (event): Promise<void> => {
+				if (!core) {
+					throw new Error('Module core is not initialized');
+				}
+
+				const title = String(event.options.title || '');
+				const useTemplate = !!event.options.use_template;
+				if (!useTemplate && (!title || title.length === 0)) {
+					throw new Error('Title is required when not using a template');
+				}
+				if (title.length > 100) {
+					throw new Error('Title must be 100 characters or less');
+				}
+
+				let scheduledStartTime: string;
+				switch (event.options.start_time_type) {
+					case 'now':
+						scheduledStartTime = new Date().toISOString();
+						break;
+					case 'minutes': {
+						const minutesStr = String(event.options.minutes_from_now || '5');
+						const minutes = parseInt(minutesStr, 10);
+						if (isNaN(minutes) || minutes < 0) {
+							throw new Error('Invalid minutes value');
+						}
+						scheduledStartTime = new Date(Date.now() + minutes * 60 * 1000).toISOString();
+						break;
+					}
+					case 'custom':
+						scheduledStartTime = String(event.options.custom_start_time || '');
+						if (!scheduledStartTime) {
+							throw new Error('Custom start time is required');
+						}
+						break;
+					default:
+						scheduledStartTime = new Date().toISOString();
+				}
+
+				const privacyStr = String(event.options.privacy || '');
+				let privacy: Visibility;
+				if (privacyStr) {
+					const lowerPrivacy = privacyStr.toLowerCase();
+					const validPrivacy = Object.values(Visibility).find((v) => (v as string) === lowerPrivacy);
+					if (!validPrivacy) {
+						throw new Error(`Invalid privacy value: ${privacyStr} (must be private, unlisted, or public)`);
+					}
+					privacy = validPrivacy;
+				} else {
+					privacy = Visibility.Private;
+				}
+
+				const description = String(event.options.description || '');
+
+				let autoStart: boolean | undefined;
+				let autoStop: boolean | undefined;
+				if (event.options.auto_start === 'yes') autoStart = true;
+				else if (event.options.auto_start === 'no') autoStart = false;
+				if (event.options.auto_stop === 'yes') autoStop = true;
+				else if (event.options.auto_stop === 'no') autoStop = false;
+
+				let templateId: BroadcastID | undefined;
+				if (event.options.use_template) {
+					if (event.options.template_id_is_text) {
+						templateId = String(event.options.template_id_text || '');
+					} else {
+						templateId = String(event.options.template_id || '');
+					}
+					if (templateId && templateId.startsWith('unfinished_')) {
+						const hit = core.Cache.UnfinishedBroadcasts.find((_a, i) => `unfinished_${i}` === templateId);
+						if (hit) {
+							templateId = hit.Id;
+						}
+					}
+				}
+
+				const thumbnailPath = String(event.options.thumbnail_path || '');
+
+				let streamId: string | undefined;
+				if (event.options.bind_stream) {
+					if (event.options.stream_id_is_text) {
+						streamId = String(event.options.stream_id_text || '');
+					} else {
+						streamId = String(event.options.stream_id || '');
+					}
+				}
+
+				await core.createBroadcast(
+					title,
+					scheduledStartTime,
+					privacy,
+					description || undefined,
+					autoStart,
+					autoStop,
+					templateId || undefined,
+					thumbnailPath || undefined,
+					streamId || undefined
+				);
+			},
+		},
+		[ActionId.SetThumbnail]: {
+			name: 'Set broadcast thumbnail',
+			description: 'Upload and set a custom thumbnail image. Must be JPEG or PNG, max 2MB.',
+			options: [
+				...selectFromAllBroadcasts,
+				{
+					type: 'textinput',
+					label: 'Image path or URL:',
+					id: 'image_path',
+					required: true,
+					description: 'Local file path or URL to JPEG/PNG image (max 2MB)',
+					useVariables: true,
+				},
+			],
+			callback: broadcastCallback(async (core, broadcastId, event) => {
+				const imagePath = String(event.options.image_path || '');
+				if (!imagePath) {
+					throw new Error('Image path is required');
+				}
+
+				return core.setThumbnail(broadcastId, imagePath);
+			}),
+		},
+		[ActionId.BindStream]: {
+			name: 'Bind stream to broadcast',
+			description: 'Bind a video stream to a broadcast. Required before going live.',
+			options: [
+				...selectFromAllBroadcasts,
+				{
+					type: 'checkbox',
+					label: 'Specify stream ID from text',
+					id: 'stream_id_is_text',
+					default: false,
+				},
+				{
+					type: 'dropdown',
+					label: 'Stream:',
+					id: 'stream_id',
+					choices: streamEntries,
+					default: defaultStream,
+					isVisibleExpression: '!$(options:stream_id_is_text)',
+				},
+				{
+					type: 'textinput',
+					label: 'Stream ID:',
+					id: 'stream_id_text',
+					description: 'Found in YouTube Studio > Go Live > Stream Settings',
+					useVariables: true,
+					isVisibleExpression: '!!$(options:stream_id_is_text)',
+				},
+			],
+			callback: broadcastCallback(async (core, broadcastId, event) => {
+				let streamId: string;
+				if (event.options.stream_id_is_text) {
+					streamId = String(event.options.stream_id_text || '');
+				} else {
+					streamId = String(event.options.stream_id || '');
+				}
+
+				if (!streamId) {
+					throw new Error('Stream ID is required');
+				}
+
+				return core.bindStream(broadcastId, streamId);
 			}),
 		},
 	};

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -118,6 +118,8 @@ export function listActions({
 		};
 	};
 
+	const allBroadcasts = Object.values(broadcasts);
+
 	// We expose all requested unfinished broadcasts, without any filtering.
 	// These seem always to have been exposed a bit prospectively, regardless
 	// whether there are actually any unfinished broadcasts to expose.
@@ -439,18 +441,13 @@ export function listActions({
 					label: 'Template broadcast:',
 					id: 'template_id',
 					choices: [
-						...Object.values(broadcasts).map((item): DropdownChoice => ({ id: item.Id, label: item.Name })),
+						...allBroadcasts.map((item): DropdownChoice => ({ id: item.Id, label: item.Name })),
 						...Array(unfinishedCount)
 							.keys()
 							.toArray()
 							.map((i): DropdownChoice => ({ id: `unfinished_${i}`, label: `Unfinished/planned #${i}` })),
 					],
-					default:
-						Object.values(broadcasts).length > 0
-							? Object.values(broadcasts)[0].Id
-							: unfinishedCount > 0
-								? 'unfinished_0'
-								: '',
+					default: allBroadcasts.length > 0 ? allBroadcasts[0].Id : unfinishedCount > 0 ? 'unfinished_0' : '',
 					isVisibleExpression: '!!$(options:use_template) && !$(options:template_id_is_text)',
 				},
 				{

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -606,8 +606,7 @@ export function listActions({
 				const privacyStr = String(options.privacy || '');
 				let privacy: Visibility;
 				if (privacyStr) {
-					const lowerPrivacy = privacyStr.toLowerCase();
-					const validPrivacy = Object.values(Visibility).find((v) => (v as string) === lowerPrivacy);
+					const validPrivacy = Object.values(Visibility).find((v) => (v as string) === privacyStr);
 					if (!validPrivacy) {
 						throw new Error(`Invalid privacy value: ${privacyStr} (must be private, unlisted, or public)`);
 					}

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -440,9 +440,10 @@ export function listActions({
 					id: 'template_id',
 					choices: [
 						...Object.values(broadcasts).map((item): DropdownChoice => ({ id: item.Id, label: item.Name })),
-						...[...Array(unfinishedCount).keys()].map(
-							(i): DropdownChoice => ({ id: `unfinished_${i}`, label: `Unfinished/planned #${i}` })
-						),
+						...Array(unfinishedCount)
+							.keys()
+							.toArray()
+							.map((i): DropdownChoice => ({ id: `unfinished_${i}`, label: `Unfinished/planned #${i}` })),
 					],
 					default:
 						Object.values(broadcasts).length > 0

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -582,9 +582,6 @@ export function listActions({
 
 				let scheduledStartTime: string;
 				switch (options.start_time_type) {
-					case 'now':
-						scheduledStartTime = new Date().toISOString();
-						break;
 					case 'minutes': {
 						const minutesStr = String(options.minutes_from_now || '5');
 						const minutes = parseInt(minutesStr, 10);
@@ -600,8 +597,10 @@ export function listActions({
 							throw new Error('Custom start time is required');
 						}
 						break;
+					case 'now':
 					default:
 						scheduledStartTime = new Date().toISOString();
+						break;
 				}
 
 				const privacyStr = String(options.privacy || '');

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -477,7 +477,7 @@ export function listActions({
 					type: 'textinput',
 					label: 'Thumbnail:',
 					id: 'thumbnail_path',
-					description: 'Local file path or URL to JPEG/PNG image (max 2MB)',
+					description: 'Local file path to a JPEG/PNG image (max 2MB)',
 					useVariables: { local: true },
 				},
 				{
@@ -670,10 +670,10 @@ export function listActions({
 				...selectFromAllBroadcasts,
 				{
 					type: 'textinput',
-					label: 'Image path or URL:',
+					label: 'Image path:',
 					id: 'image_path',
 					required: true,
-					description: 'Local file path or URL to JPEG/PNG image (max 2MB)',
+					description: 'Local file path to a JPEG/PNG image (max 2MB)',
 					useVariables: { local: true },
 				},
 			],

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -115,6 +115,9 @@ export interface Stream {
 
 	/** Health metric of this stream */
 	Health: StreamHealth;
+
+	/** Display name of the stream */
+	Name?: string;
 }
 
 /**
@@ -124,9 +127,15 @@ export interface StateMemory {
 	/** All fetched broadcasts. */
 	Broadcasts: Record<BroadcastID, Broadcast>;
 
-	/** All fetched streams */
+	/** All fetched streams (with names, for dropdowns) */
 	Streams: Record<StreamID, Stream>;
+
+	/** Streams bound to broadcasts (for health monitoring) */
+	BoundStreams: Record<StreamID, Stream>;
 
 	/** Unfinished broadcasts */
 	UnfinishedBroadcasts: Array<Broadcast>;
+
+	/** Most recently created broadcast */
+	LastCreatedBroadcast: Broadcast | null;
 }

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -49,8 +49,8 @@ export interface Stream {
 	/** Health metric of this stream */
 	Health: StreamHealth;
 
-	/** Display name of the stream */
-	Name?: string;
+	/** Display name of the stream, if any. */
+	Name: string | null;
 }
 
 /** Map of all fetched broadcasts */

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -48,6 +48,9 @@ export interface Stream {
 
 	/** Health metric of this stream */
 	Health: StreamHealth;
+
+	/** Display name of the stream */
+	Name?: string;
 }
 
 /** Map of all fetched broadcasts */
@@ -63,11 +66,17 @@ export interface StateMemory {
 	/** All fetched broadcasts. */
 	Broadcasts: Record<BroadcastID, Broadcast>;
 
-	/** All fetched streams */
+	/** All fetched streams (with names, for dropdowns) */
 	Streams: Record<StreamID, Stream>;
+
+	/** Streams bound to broadcasts (for health monitoring) */
+	BoundStreams: Record<StreamID, Stream>;
 
 	/** Unfinished broadcasts */
 	UnfinishedBroadcasts: Array<Broadcast>;
+
+	/** Most recently created broadcast */
+	LastCreatedBroadcast: Broadcast | null;
 }
 
 const lifecycleToNumberMap: Record<BroadcastLifecycle, number> = {

--- a/src/core.test.ts
+++ b/src/core.test.ts
@@ -50,6 +50,13 @@ describe('Miscellaneous', () => {
 					Description: '',
 				},
 			],
+			BoundStreams: {
+				sA: {
+					Id: 'sA',
+					Health: StreamHealth.Good,
+				},
+			},
+			LastCreatedBroadcast: null,
 		};
 		mockYT = vi.mocked(makeMockYT(memory));
 		mockModule = vi.mocked(makeMockModule());
@@ -72,6 +79,7 @@ describe('Miscellaneous', () => {
 		expect(mockModule.reloadAll).toHaveBeenCalledWith(core.Cache);
 		expect(mockYT.listBroadcasts).toHaveBeenCalledTimes(1);
 		expect(mockYT.listBoundStreams).toHaveBeenCalledTimes(1);
+		expect(mockYT.listStreams).toHaveBeenCalledTimes(1);
 	});
 
 	test('Periodic callback works', async () => {
@@ -178,6 +186,8 @@ describe('Starting tests on broadcasts', () => {
 				},
 			},
 			UnfinishedBroadcasts: [],
+			BoundStreams: {},
+			LastCreatedBroadcast: null,
 		};
 		mockYT = vi.mocked(makeMockYT(memory));
 		mockModule = vi.mocked(makeMockModule());
@@ -274,6 +284,8 @@ describe('Going live with broadcasts', () => {
 				},
 			},
 			UnfinishedBroadcasts: [],
+			BoundStreams: {},
+			LastCreatedBroadcast: null,
 		};
 		mockYT = vi.mocked(makeMockYT(memory));
 		mockModule = vi.mocked(makeMockModule());
@@ -376,6 +388,8 @@ describe('Finishing live broadcasts', () => {
 				},
 			},
 			UnfinishedBroadcasts: [],
+			BoundStreams: {},
+			LastCreatedBroadcast: null,
 		};
 		mockYT = vi.mocked(makeMockYT(memory));
 		mockModule = vi.mocked(makeMockModule());
@@ -441,6 +455,8 @@ describe('Toggling live broadcasts', () => {
 				},
 			},
 			UnfinishedBroadcasts: [],
+			BoundStreams: {},
+			LastCreatedBroadcast: null,
 		};
 		mockYT = vi.mocked(makeMockYT(memory));
 		mockModule = vi.mocked(makeMockModule());

--- a/src/core.test.ts
+++ b/src/core.test.ts
@@ -37,6 +37,7 @@ describe('Miscellaneous', () => {
 				sA: {
 					Id: 'sA',
 					Health: StreamHealth.Good,
+					Name: null,
 				},
 			},
 			UnfinishedBroadcasts: [
@@ -58,6 +59,7 @@ describe('Miscellaneous', () => {
 				sA: {
 					Id: 'sA',
 					Health: StreamHealth.Good,
+					Name: null,
 				},
 			},
 			LastCreatedBroadcast: null,
@@ -188,6 +190,7 @@ describe('Starting tests on broadcasts', () => {
 				sA: {
 					Id: 'sA',
 					Health: StreamHealth.Good,
+					Name: null,
 				},
 			},
 			UnfinishedBroadcasts: [],
@@ -287,6 +290,7 @@ describe('Going live with broadcasts', () => {
 				sA: {
 					Id: 'sA',
 					Health: StreamHealth.Good,
+					Name: null,
 				},
 			},
 			UnfinishedBroadcasts: [],
@@ -392,6 +396,7 @@ describe('Finishing live broadcasts', () => {
 				sA: {
 					Id: 'sA',
 					Health: StreamHealth.Good,
+					Name: null,
 				},
 			},
 			UnfinishedBroadcasts: [],
@@ -460,6 +465,7 @@ describe('Toggling live broadcasts', () => {
 				sA: {
 					Id: 'sA',
 					Health: StreamHealth.Good,
+					Name: null,
 				},
 			},
 			UnfinishedBroadcasts: [],

--- a/src/core.test.ts
+++ b/src/core.test.ts
@@ -54,6 +54,13 @@ describe('Miscellaneous', () => {
 					Visibility: Visibility.Private,
 				},
 			],
+			BoundStreams: {
+				sA: {
+					Id: 'sA',
+					Health: StreamHealth.Good,
+				},
+			},
+			LastCreatedBroadcast: null,
 		};
 		mockYT = vi.mocked(makeMockYT(memory));
 		mockModule = vi.mocked(makeMockModule());
@@ -76,6 +83,7 @@ describe('Miscellaneous', () => {
 		expect(mockModule.reloadAll).toHaveBeenCalledWith(core.Cache);
 		expect(mockYT.listBroadcasts).toHaveBeenCalledTimes(1);
 		expect(mockYT.listBoundStreams).toHaveBeenCalledTimes(1);
+		expect(mockYT.listStreams).toHaveBeenCalledTimes(1);
 	});
 
 	test('Periodic callback works', async () => {
@@ -183,6 +191,8 @@ describe('Starting tests on broadcasts', () => {
 				},
 			},
 			UnfinishedBroadcasts: [],
+			BoundStreams: {},
+			LastCreatedBroadcast: null,
 		};
 		mockYT = vi.mocked(makeMockYT(memory));
 		mockModule = vi.mocked(makeMockModule());
@@ -280,6 +290,8 @@ describe('Going live with broadcasts', () => {
 				},
 			},
 			UnfinishedBroadcasts: [],
+			BoundStreams: {},
+			LastCreatedBroadcast: null,
 		};
 		mockYT = vi.mocked(makeMockYT(memory));
 		mockModule = vi.mocked(makeMockModule());
@@ -383,6 +395,8 @@ describe('Finishing live broadcasts', () => {
 				},
 			},
 			UnfinishedBroadcasts: [],
+			BoundStreams: {},
+			LastCreatedBroadcast: null,
 		};
 		mockYT = vi.mocked(makeMockYT(memory));
 		mockModule = vi.mocked(makeMockModule());
@@ -449,6 +463,8 @@ describe('Toggling live broadcasts', () => {
 				},
 			},
 			UnfinishedBroadcasts: [],
+			BoundStreams: {},
+			LastCreatedBroadcast: null,
 		};
 		mockYT = vi.mocked(makeMockYT(memory));
 		mockModule = vi.mocked(makeMockModule());

--- a/src/core.test.ts
+++ b/src/core.test.ts
@@ -1,6 +1,9 @@
 import { afterAll, afterEach, beforeEach, describe, expect, type MockedObject, test, vi } from 'vitest';
 
 //require("leaked-handles");
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import type { YoutubeAPI } from './youtube.js';
 import { type ModuleBase, Core } from './core.js';
 import { sleep } from './common.js';
@@ -560,5 +563,62 @@ describe('Toggling live broadcasts', () => {
 			memory.Broadcasts.bA.Status = key;
 			await expect(core.toggleBroadcast('bA')).rejects.toBeInstanceOf(Error);
 		}
+	});
+});
+
+describe('Setting broadcast thumbnails', () => {
+	const PNG_MAGIC = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+	const JPEG_MAGIC = Buffer.from([0xff, 0xd8, 0xff, 0xe0]);
+
+	let mockYT: MockedObject<YoutubeAPI>;
+	let mockModule: MockedObject<ModuleBase>;
+	let core: Core;
+	let tmpDir: string;
+
+	beforeEach(async () => {
+		const memory: StateMemory = {
+			Broadcasts: {},
+			Streams: {},
+			UnfinishedBroadcasts: [],
+			BoundStreams: {},
+			LastCreatedBroadcast: null,
+		};
+		mockYT = vi.mocked(makeMockYT(memory));
+		mockModule = vi.mocked(makeMockModule());
+		core = new Core(mockModule, mockYT, 100, 100);
+		tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'yt-thumb-'));
+	});
+
+	afterEach(async () => {
+		core.destroy();
+		await fs.rm(tmpDir, { recursive: true, force: true });
+	});
+
+	async function writeTmp(name: string, data: Buffer): Promise<string> {
+		const filePath = path.join(tmpDir, name);
+		await fs.writeFile(filePath, data);
+		return filePath;
+	}
+
+	test.each<[string, string, Buffer]>([
+		// The first two prove magic bytes win over a contradicting extension;
+		// the last proves the extension is the fallback when magic bytes are absent.
+		['mislabeled.jpg', 'image/png', PNG_MAGIC],
+		['mislabeled.png', 'image/jpeg', JPEG_MAGIC],
+		['image.png', 'image/png', Buffer.from('not really a png')],
+	])('Uploads %s as %s', async (name, mime, data) => {
+		await core.setThumbnail('bId', await writeTmp(name, data));
+		expect(mockYT.setThumbnail).toHaveBeenCalledWith('bId', expect.any(Buffer), mime);
+	});
+
+	test.each<[string, () => Promise<string>, RegExp]>([
+		['a remote http URL', async () => 'http://example.com/thumb.png', /Remote thumbnail URLs are not supported/],
+		['a remote https URL', async () => 'https://example.com/thumb.jpg', /Remote thumbnail URLs are not supported/],
+		['a nonexistent path', async () => path.join(tmpDir, 'nope.png'), /not found or inaccessible/],
+		['a non-image file', async () => writeTmp('notes.txt', Buffer.from('plain text')), /Invalid thumbnail type/],
+		['a file larger than 2MB', async () => writeTmp('big.png', Buffer.alloc(2 * 1024 * 1024 + 1)), /too large/],
+	])('Rejects %s without calling the YouTube API', async (_desc, makePath, error) => {
+		await expect(core.setThumbnail('bId', await makePath())).rejects.toThrow(error);
+		expect(mockYT.setThumbnail).not.toHaveBeenCalled();
 	});
 });

--- a/src/core.ts
+++ b/src/core.ts
@@ -1,6 +1,9 @@
-import { type StateMemory, type BroadcastID, BroadcastLifecycle, type Broadcast } from './cache.js';
+import { type StateMemory, type BroadcastID, BroadcastLifecycle, type Broadcast, type StreamMap } from './cache.js';
 import { Transition, type Visibility, type YoutubeAPI } from './youtube.js';
 import type { Logger } from './common.js';
+import * as fs from 'fs';
+import * as https from 'https';
+import * as http from 'http';
 
 /**
  * Interface between executive core and the Companion module glue
@@ -66,7 +69,13 @@ export class Core {
 	constructor(mod: ModuleBase, api: YoutubeAPI, refreshInterval: number, pollInterval = 1000) {
 		this.Module = mod;
 		this.YouTube = api;
-		this.Cache = { Broadcasts: {}, Streams: {}, UnfinishedBroadcasts: [] };
+		this.Cache = {
+			Broadcasts: {},
+			Streams: {},
+			BoundStreams: {},
+			UnfinishedBroadcasts: [],
+			LastCreatedBroadcast: null,
+		};
 		this.RefreshInterval = refreshInterval;
 		this.TransitionPollInterval = pollInterval;
 		this.RunningTransitions = {};
@@ -78,7 +87,8 @@ export class Core {
 	 */
 	async init(): Promise<void> {
 		this.Cache.Broadcasts = await this.YouTube.listBroadcasts();
-		this.Cache.Streams = await this.YouTube.listBoundStreams(this.Cache.Broadcasts);
+		this.Cache.BoundStreams = await this.YouTube.listBoundStreams(this.Cache.Broadcasts);
+		this.Cache.Streams = await this.YouTube.listStreams();
 
 		const unfinished = Object.values(this.Cache.Broadcasts).filter((broadcast: Broadcast): boolean => {
 			// Filter only unfinished broadcasts.
@@ -112,7 +122,7 @@ export class Core {
 	async refresher(): Promise<void> {
 		try {
 			this.Cache.Broadcasts = await this.YouTube.refreshBroadcastStatus(this.Cache.Broadcasts);
-			this.Cache.Streams = await this.YouTube.listBoundStreams(this.Cache.Broadcasts);
+			this.Cache.BoundStreams = await this.YouTube.listBoundStreams(this.Cache.Broadcasts);
 			// update existing unfinished broadcasts store
 			this.Cache.UnfinishedBroadcasts = this.Cache.UnfinishedBroadcasts.map((a) => {
 				return a.Id in this.Cache.Broadcasts ? this.Cache.Broadcasts[a.Id] : a;
@@ -475,6 +485,197 @@ export class Core {
 
 	async setVisibility(id: BroadcastID, visibility: Visibility): Promise<void> {
 		return this.YouTube.setVisibility(id, visibility);
+	}
+
+	async createBroadcast(
+		title: string,
+		scheduledStartTime: string,
+		privacyStatus: Visibility,
+		description?: string,
+		enableAutoStart?: boolean,
+		enableAutoStop?: boolean,
+		templateId?: BroadcastID,
+		thumbnailPath?: string,
+		streamId?: string
+	): Promise<BroadcastID> {
+		this.Cache.LastCreatedBroadcast = null;
+
+		if (description && description.length > 5000) {
+			throw new Error(`Description must not exceed 5000 characters (got ${description.length})`);
+		}
+
+		let finalTitle = title;
+		let finalDescription = description;
+		let enableMonitorStream: boolean | undefined = undefined;
+		let finalStreamId = streamId;
+
+		if (templateId && this.Cache.Broadcasts[templateId]) {
+			const template = this.Cache.Broadcasts[templateId];
+			if (!finalTitle || finalTitle.length === 0) {
+				finalTitle = template.Name;
+			}
+			if (finalDescription === undefined) {
+				finalDescription = template.Description;
+			}
+			enableMonitorStream = template.MonitorStreamEnabled;
+			if (!finalStreamId && template.BoundStreamId) {
+				finalStreamId = template.BoundStreamId;
+			}
+		}
+
+		if (!finalTitle || finalTitle.length === 0 || finalTitle.length > 100) {
+			throw new Error(`Title must be between 1 and 100 characters (got ${finalTitle?.length ?? 0})`);
+		}
+
+		const broadcastId = await this.YouTube.createBroadcast(
+			finalTitle,
+			scheduledStartTime,
+			privacyStatus,
+			finalDescription,
+			enableAutoStart,
+			enableAutoStop,
+			enableMonitorStream
+		);
+
+		this.Module.log('info', `Created broadcast: ${broadcastId}`);
+
+		if (thumbnailPath) {
+			await this.setThumbnail(broadcastId, thumbnailPath);
+		}
+
+		if (finalStreamId) {
+			await this.YouTube.bindBroadcastToStream(broadcastId, finalStreamId);
+			this.Module.log('info', `Bound stream ${finalStreamId} to broadcast ${broadcastId}`);
+		}
+
+		await this.reloadEverything();
+
+		// Set after reload so we have the full broadcast data
+		this.Cache.LastCreatedBroadcast = this.Cache.Broadcasts[broadcastId] || null;
+		this.Module.reloadStates(this.Cache);
+
+		return broadcastId;
+	}
+
+	async setThumbnail(broadcastId: BroadcastID, imagePath: string): Promise<void> {
+		const maxSize = 2 * 1024 * 1024;
+		let imageData: Buffer;
+		let mimeType: string;
+
+		if (imagePath.startsWith('http://') || imagePath.startsWith('https://')) {
+			const result = await this.fetchImageFromUrl(imagePath);
+			imageData = result.data;
+			mimeType = result.mimeType;
+		} else {
+			if (!fs.existsSync(imagePath)) {
+				throw new Error(`Thumbnail file not found: ${imagePath}`);
+			}
+
+			const stat = fs.statSync(imagePath);
+			if (stat.size > maxSize) {
+				throw new Error(`Thumbnail file too large: ${stat.size} bytes (max 2MB)`);
+			}
+
+			imageData = fs.readFileSync(imagePath);
+			mimeType = this.detectMimeType(imageData, imagePath);
+		}
+
+		if (imageData.length > maxSize) {
+			throw new Error(`Thumbnail data too large: ${imageData.length} bytes (max 2MB)`);
+		}
+
+		if (mimeType !== 'image/jpeg' && mimeType !== 'image/png') {
+			throw new Error(`Invalid thumbnail type: ${mimeType} (must be JPEG or PNG)`);
+		}
+
+		await this.YouTube.setThumbnail(broadcastId, imageData, mimeType);
+		this.Module.log('info', `Set thumbnail for broadcast: ${broadcastId}`);
+	}
+
+	async getAvailableStreams(): Promise<StreamMap> {
+		return this.YouTube.listStreams();
+	}
+
+	async bindStream(broadcastId: BroadcastID, streamId: string): Promise<void> {
+		await this.YouTube.bindBroadcastToStream(broadcastId, streamId);
+		this.Module.log('info', `Bound stream ${streamId} to broadcast ${broadcastId}`);
+		await this.reloadEverything();
+	}
+
+	async unbindStream(broadcastId: BroadcastID): Promise<void> {
+		await this.YouTube.bindBroadcastToStream(broadcastId);
+		this.Module.log('info', `Unbound stream from broadcast ${broadcastId}`);
+		await this.reloadEverything();
+	}
+
+	private async fetchImageFromUrl(url: string, remainingRedirects = 5): Promise<{ data: Buffer; mimeType: string }> {
+		return new Promise((resolve, reject) => {
+			const protocol = url.startsWith('https://') ? https : http;
+
+			const request = protocol.get(url, { timeout: 30000 }, (response) => {
+				if (
+					response.statusCode &&
+					response.statusCode >= 300 &&
+					response.statusCode < 400 &&
+					response.headers.location
+				) {
+					if (remainingRedirects <= 0) {
+						reject(new Error('Too many redirects'));
+						return;
+					}
+					this.fetchImageFromUrl(response.headers.location, remainingRedirects - 1)
+						.then(resolve)
+						.catch(reject);
+					return;
+				}
+
+				if (response.statusCode !== 200) {
+					reject(new Error(`Failed to fetch image: HTTP ${response.statusCode}`));
+					return;
+				}
+
+				const chunks: Buffer[] = [];
+				response.on('data', (chunk: Buffer) => chunks.push(chunk));
+				response.on('end', () => {
+					const data = Buffer.concat(chunks);
+					const contentType = response.headers['content-type'] || '';
+					let mimeType = contentType.split(';')[0].trim();
+
+					if (mimeType !== 'image/jpeg' && mimeType !== 'image/png') {
+						mimeType = this.detectMimeType(data, url);
+					}
+
+					resolve({ data, mimeType });
+				});
+				response.on('error', reject);
+			});
+
+			request.on('timeout', () => {
+				request.destroy();
+				reject(new Error('Request timeout'));
+			});
+
+			request.on('error', reject);
+		});
+	}
+
+	private detectMimeType(data: Buffer, path: string): string {
+		if (data.length >= 3 && data[0] === 0xff && data[1] === 0xd8 && data[2] === 0xff) {
+			return 'image/jpeg';
+		}
+		if (data.length >= 8 && data[0] === 0x89 && data[1] === 0x50 && data[2] === 0x4e && data[3] === 0x47) {
+			return 'image/png';
+		}
+
+		const lowerPath = path.toLowerCase();
+		if (lowerPath.endsWith('.jpg') || lowerPath.endsWith('.jpeg')) {
+			return 'image/jpeg';
+		}
+		if (lowerPath.endsWith('.png')) {
+			return 'image/png';
+		}
+
+		return 'application/octet-stream';
 	}
 }
 

--- a/src/core.ts
+++ b/src/core.ts
@@ -24,6 +24,49 @@ export interface ModuleBase {
 	log: Logger;
 }
 
+interface CreateBroadcastParameters {
+	/** The title of the broadcast.  Must not be empty. */
+	title: string;
+
+	/** ISO 8601 formatted start time. */
+	scheduledStartTime: string;
+
+	/** How publicly visible (public/private/unlisted) the broadcast will be. */
+	privacyStatus: Visibility;
+
+	/** The description of the broadcast. */
+	description?: string;
+
+	/**
+	 * Whether the broadcast should automatically start once streaming video data
+	 * is received.
+	 */
+	enableAutoStart?: boolean;
+
+	/**
+	 * Whether the broadcast should automatically end when streaming video data
+	 * stops being received (plus a tiny buffer to account for unstable network
+	 * conditions).
+	 */
+	enableAutoStop?: boolean;
+
+	/**
+	 * If supplied, the broadcast ID of a broadcast that will fill in title,
+	 * description, and stream to associate with this broadcast if any of these
+	 * weren't specified.
+	 */
+	templateId?: BroadcastID;
+
+	/**
+	 * A URL (http: or https:) or a file path to a JPEG/PNG thumbnail image to
+	 * associate with the broadcast.
+	 */
+	thumbnailPath?: string;
+
+	/** The ID of a stream to associate with the broadcast. */
+	streamId?: string;
+}
+
 /**
  * Executive core of the module
  */
@@ -489,17 +532,17 @@ export class Core {
 		return this.YouTube.setVisibility(id, visibility);
 	}
 
-	async createBroadcast(
-		title: string,
-		scheduledStartTime: string,
-		privacyStatus: Visibility,
-		description?: string,
-		enableAutoStart?: boolean,
-		enableAutoStop?: boolean,
-		templateId?: BroadcastID,
-		thumbnailPath?: string,
-		streamId?: string
-	): Promise<BroadcastID> {
+	async createBroadcast({
+		title,
+		scheduledStartTime,
+		privacyStatus,
+		description,
+		enableAutoStart,
+		enableAutoStop,
+		templateId,
+		thumbnailPath,
+		streamId,
+	}: CreateBroadcastParameters): Promise<BroadcastID> {
 		this.Cache.LastCreatedBroadcast = null;
 
 		if (description && description.length > 5000) {
@@ -529,15 +572,15 @@ export class Core {
 			throw new Error(`Title must be between 1 and 100 characters (got ${finalTitle?.length ?? 0})`);
 		}
 
-		const broadcastId = await this.YouTube.createBroadcast(
-			finalTitle,
+		const broadcastId = await this.YouTube.createBroadcast({
+			title: finalTitle,
 			scheduledStartTime,
 			privacyStatus,
-			finalDescription,
+			description: finalDescription,
 			enableAutoStart,
 			enableAutoStop,
-			enableMonitorStream
-		);
+			enableMonitorStream,
+		});
 
 		this.Module.log('info', `Created broadcast: ${broadcastId}`);
 

--- a/src/core.ts
+++ b/src/core.ts
@@ -1,4 +1,7 @@
-import type { Broadcast, StateMemory } from './cache.js';
+import * as fs from 'node:fs';
+import * as https from 'node:https';
+import * as http from 'node:http';
+import type { Broadcast, StateMemory, StreamMap } from './cache.js';
 import type { Logger } from './common.js';
 import { BroadcastLifecycle } from './lifecycle.js';
 import type { BroadcastID, Visibility } from './types.js';
@@ -68,7 +71,13 @@ export class Core {
 	constructor(mod: ModuleBase, api: YoutubeAPI, refreshInterval: number, pollInterval = 1000) {
 		this.Module = mod;
 		this.YouTube = api;
-		this.Cache = { Broadcasts: {}, Streams: {}, UnfinishedBroadcasts: [] };
+		this.Cache = {
+			Broadcasts: {},
+			Streams: {},
+			BoundStreams: {},
+			UnfinishedBroadcasts: [],
+			LastCreatedBroadcast: null,
+		};
 		this.RefreshInterval = refreshInterval;
 		this.TransitionPollInterval = pollInterval;
 		this.RunningTransitions = {};
@@ -80,7 +89,8 @@ export class Core {
 	 */
 	async init(): Promise<void> {
 		this.Cache.Broadcasts = await this.YouTube.listBroadcasts();
-		this.Cache.Streams = await this.YouTube.listBoundStreams(this.Cache.Broadcasts);
+		this.Cache.BoundStreams = await this.YouTube.listBoundStreams(this.Cache.Broadcasts);
+		this.Cache.Streams = await this.YouTube.listStreams();
 
 		const unfinished = Object.values(this.Cache.Broadcasts).filter((broadcast: Broadcast): boolean => {
 			// Filter only unfinished broadcasts.
@@ -114,7 +124,7 @@ export class Core {
 	async refresher(): Promise<void> {
 		try {
 			this.Cache.Broadcasts = await this.YouTube.refreshBroadcastStatus(this.Cache.Broadcasts);
-			this.Cache.Streams = await this.YouTube.listBoundStreams(this.Cache.Broadcasts);
+			this.Cache.BoundStreams = await this.YouTube.listBoundStreams(this.Cache.Broadcasts);
 			// update existing unfinished broadcasts store
 			this.Cache.UnfinishedBroadcasts = this.Cache.UnfinishedBroadcasts.map((a) => {
 				return a.Id in this.Cache.Broadcasts ? this.Cache.Broadcasts[a.Id] : a;
@@ -477,6 +487,197 @@ export class Core {
 
 	async setVisibility(id: BroadcastID, visibility: Visibility): Promise<void> {
 		return this.YouTube.setVisibility(id, visibility);
+	}
+
+	async createBroadcast(
+		title: string,
+		scheduledStartTime: string,
+		privacyStatus: Visibility,
+		description?: string,
+		enableAutoStart?: boolean,
+		enableAutoStop?: boolean,
+		templateId?: BroadcastID,
+		thumbnailPath?: string,
+		streamId?: string
+	): Promise<BroadcastID> {
+		this.Cache.LastCreatedBroadcast = null;
+
+		if (description && description.length > 5000) {
+			throw new Error(`Description must not exceed 5000 characters (got ${description.length})`);
+		}
+
+		let finalTitle = title;
+		let finalDescription = description;
+		let enableMonitorStream: boolean | undefined = undefined;
+		let finalStreamId = streamId;
+
+		if (templateId && this.Cache.Broadcasts[templateId]) {
+			const template = this.Cache.Broadcasts[templateId];
+			if (!finalTitle || finalTitle.length === 0) {
+				finalTitle = template.Name;
+			}
+			if (finalDescription === undefined) {
+				finalDescription = template.Description;
+			}
+			enableMonitorStream = template.MonitorStreamEnabled;
+			if (!finalStreamId && template.BoundStreamId) {
+				finalStreamId = template.BoundStreamId;
+			}
+		}
+
+		if (!finalTitle || finalTitle.length === 0 || finalTitle.length > 100) {
+			throw new Error(`Title must be between 1 and 100 characters (got ${finalTitle?.length ?? 0})`);
+		}
+
+		const broadcastId = await this.YouTube.createBroadcast(
+			finalTitle,
+			scheduledStartTime,
+			privacyStatus,
+			finalDescription,
+			enableAutoStart,
+			enableAutoStop,
+			enableMonitorStream
+		);
+
+		this.Module.log('info', `Created broadcast: ${broadcastId}`);
+
+		if (thumbnailPath) {
+			await this.setThumbnail(broadcastId, thumbnailPath);
+		}
+
+		if (finalStreamId) {
+			await this.YouTube.bindBroadcastToStream(broadcastId, finalStreamId);
+			this.Module.log('info', `Bound stream ${finalStreamId} to broadcast ${broadcastId}`);
+		}
+
+		await this.reloadEverything();
+
+		// Set after reload so we have the full broadcast data
+		this.Cache.LastCreatedBroadcast = this.Cache.Broadcasts[broadcastId] || null;
+		this.Module.reloadStates(this.Cache);
+
+		return broadcastId;
+	}
+
+	async setThumbnail(broadcastId: BroadcastID, imagePath: string): Promise<void> {
+		const maxSize = 2 * 1024 * 1024;
+		let imageData: Buffer;
+		let mimeType: string;
+
+		if (imagePath.startsWith('http://') || imagePath.startsWith('https://')) {
+			const result = await this.fetchImageFromUrl(imagePath);
+			imageData = result.data;
+			mimeType = result.mimeType;
+		} else {
+			if (!fs.existsSync(imagePath)) {
+				throw new Error(`Thumbnail file not found: ${imagePath}`);
+			}
+
+			const stat = fs.statSync(imagePath);
+			if (stat.size > maxSize) {
+				throw new Error(`Thumbnail file too large: ${stat.size} bytes (max 2MB)`);
+			}
+
+			imageData = fs.readFileSync(imagePath);
+			mimeType = this.detectMimeType(imageData, imagePath);
+		}
+
+		if (imageData.length > maxSize) {
+			throw new Error(`Thumbnail data too large: ${imageData.length} bytes (max 2MB)`);
+		}
+
+		if (mimeType !== 'image/jpeg' && mimeType !== 'image/png') {
+			throw new Error(`Invalid thumbnail type: ${mimeType} (must be JPEG or PNG)`);
+		}
+
+		await this.YouTube.setThumbnail(broadcastId, imageData, mimeType);
+		this.Module.log('info', `Set thumbnail for broadcast: ${broadcastId}`);
+	}
+
+	async getAvailableStreams(): Promise<StreamMap> {
+		return this.YouTube.listStreams();
+	}
+
+	async bindStream(broadcastId: BroadcastID, streamId: string): Promise<void> {
+		await this.YouTube.bindBroadcastToStream(broadcastId, streamId);
+		this.Module.log('info', `Bound stream ${streamId} to broadcast ${broadcastId}`);
+		await this.reloadEverything();
+	}
+
+	async unbindStream(broadcastId: BroadcastID): Promise<void> {
+		await this.YouTube.bindBroadcastToStream(broadcastId);
+		this.Module.log('info', `Unbound stream from broadcast ${broadcastId}`);
+		await this.reloadEverything();
+	}
+
+	private async fetchImageFromUrl(url: string, remainingRedirects = 5): Promise<{ data: Buffer; mimeType: string }> {
+		return new Promise((resolve, reject) => {
+			const protocol = url.startsWith('https://') ? https : http;
+
+			const request = protocol.get(url, { timeout: 30000 }, (response) => {
+				if (
+					response.statusCode &&
+					response.statusCode >= 300 &&
+					response.statusCode < 400 &&
+					response.headers.location
+				) {
+					if (remainingRedirects <= 0) {
+						reject(new Error('Too many redirects'));
+						return;
+					}
+					this.fetchImageFromUrl(response.headers.location, remainingRedirects - 1)
+						.then(resolve)
+						.catch(reject);
+					return;
+				}
+
+				if (response.statusCode !== 200) {
+					reject(new Error(`Failed to fetch image: HTTP ${response.statusCode}`));
+					return;
+				}
+
+				const chunks: Buffer[] = [];
+				response.on('data', (chunk: Buffer) => chunks.push(chunk));
+				response.on('end', () => {
+					const data = Buffer.concat(chunks);
+					const contentType = response.headers['content-type'] || '';
+					let mimeType = contentType.split(';')[0].trim();
+
+					if (mimeType !== 'image/jpeg' && mimeType !== 'image/png') {
+						mimeType = this.detectMimeType(data, url);
+					}
+
+					resolve({ data, mimeType });
+				});
+				response.on('error', reject);
+			});
+
+			request.on('timeout', () => {
+				request.destroy();
+				reject(new Error('Request timeout'));
+			});
+
+			request.on('error', reject);
+		});
+	}
+
+	private detectMimeType(data: Buffer, path: string): string {
+		if (data.length >= 3 && data[0] === 0xff && data[1] === 0xd8 && data[2] === 0xff) {
+			return 'image/jpeg';
+		}
+		if (data.length >= 8 && data[0] === 0x89 && data[1] === 0x50 && data[2] === 0x4e && data[3] === 0x47) {
+			return 'image/png';
+		}
+
+		const lowerPath = path.toLowerCase();
+		if (lowerPath.endsWith('.jpg') || lowerPath.endsWith('.jpeg')) {
+			return 'image/jpeg';
+		}
+		if (lowerPath.endsWith('.png')) {
+			return 'image/png';
+		}
+
+		return 'application/octet-stream';
 	}
 }
 

--- a/src/core.ts
+++ b/src/core.ts
@@ -608,7 +608,7 @@ export class Core {
 		let mimeType: string;
 
 		if (imagePath.startsWith('http://') || imagePath.startsWith('https://')) {
-			const result = await this.fetchImageFromUrl(imagePath);
+			const result = await this.#fetchImageFromUrl(imagePath);
 			imageData = result.data;
 			mimeType = result.mimeType;
 		} else {
@@ -621,7 +621,7 @@ export class Core {
 			}
 
 			imageData = await fs.readFile(imagePath);
-			mimeType = this.detectMimeType(imageData, imagePath);
+			mimeType = this.#detectMimeType(imageData, imagePath);
 		}
 
 		if (imageData.length > maxSize) {
@@ -652,7 +652,7 @@ export class Core {
 		await this.reloadEverything();
 	}
 
-	private async fetchImageFromUrl(url: string, remainingRedirects = 5): Promise<{ data: Buffer; mimeType: string }> {
+	async #fetchImageFromUrl(url: string, remainingRedirects = 5): Promise<{ data: Buffer; mimeType: string }> {
 		return new Promise((resolve, reject) => {
 			const protocol = url.startsWith('https://') ? https : http;
 
@@ -667,7 +667,7 @@ export class Core {
 						reject(new Error('Too many redirects'));
 						return;
 					}
-					this.fetchImageFromUrl(response.headers.location, remainingRedirects - 1)
+					this.#fetchImageFromUrl(response.headers.location, remainingRedirects - 1)
 						.then(resolve)
 						.catch(reject);
 					return;
@@ -686,7 +686,7 @@ export class Core {
 					let mimeType = contentType.split(';')[0].trim();
 
 					if (mimeType !== 'image/jpeg' && mimeType !== 'image/png') {
-						mimeType = this.detectMimeType(data, url);
+						mimeType = this.#detectMimeType(data, url);
 					}
 
 					resolve({ data, mimeType });
@@ -703,7 +703,7 @@ export class Core {
 		});
 	}
 
-	private detectMimeType(data: Buffer, path: string): string {
+	#detectMimeType(data: Buffer, path: string): string {
 		if (data.length >= 3 && data[0] === 0xff && data[1] === 0xd8 && data[2] === 0xff) {
 			return 'image/jpeg';
 		}

--- a/src/core.ts
+++ b/src/core.ts
@@ -1,4 +1,4 @@
-import * as fs from 'node:fs';
+import * as fs from 'node:fs/promises';
 import * as https from 'node:https';
 import * as http from 'node:http';
 import type { Broadcast, StateMemory, StreamMap } from './cache.js';
@@ -612,16 +612,15 @@ export class Core {
 			imageData = result.data;
 			mimeType = result.mimeType;
 		} else {
-			if (!fs.existsSync(imagePath)) {
-				throw new Error(`Thumbnail file not found: ${imagePath}`);
+			const stat = await fs.stat(imagePath);
+			if (!stat) {
+				throw new Error(`Thumbnail file not found or inaccessible: ${imagePath}`);
 			}
-
-			const stat = fs.statSync(imagePath);
 			if (stat.size > maxSize) {
 				throw new Error(`Thumbnail file too large: ${stat.size} bytes (max 2MB)`);
 			}
 
-			imageData = fs.readFileSync(imagePath);
+			imageData = await fs.readFile(imagePath);
 			mimeType = this.detectMimeType(imageData, imagePath);
 		}
 

--- a/src/core.ts
+++ b/src/core.ts
@@ -704,9 +704,11 @@ export class Core {
 	}
 
 	#detectMimeType(data: Buffer, path: string): string {
+		// https://yasoob.me/posts/understanding-and-writing-jpeg-decoder-in-python/
 		if (data.length >= 3 && data[0] === 0xff && data[1] === 0xd8 && data[2] === 0xff) {
 			return 'image/jpeg';
 		}
+		// https://www.libpng.org/pub/png/spec/1.2/PNG-Structure.html
 		if (data.length >= 8 && data[0] === 0x89 && data[1] === 0x50 && data[2] === 0x4e && data[3] === 0x47) {
 			return 'image/png';
 		}

--- a/src/core.ts
+++ b/src/core.ts
@@ -1,6 +1,4 @@
 import * as fs from 'node:fs/promises';
-import * as https from 'node:https';
-import * as http from 'node:http';
 import type { Broadcast, StateMemory, StreamMap } from './cache.js';
 import type { Logger } from './common.js';
 import { BroadcastLifecycle } from './lifecycle.js';
@@ -58,8 +56,8 @@ interface CreateBroadcastParameters {
 	templateId?: BroadcastID;
 
 	/**
-	 * A URL (http: or https:) or a file path to a JPEG/PNG thumbnail image to
-	 * associate with the broadcast.
+	 * A local file path to a JPEG/PNG thumbnail image to associate with the
+	 * broadcast.
 	 */
 	thumbnailPath?: string;
 
@@ -604,29 +602,25 @@ export class Core {
 
 	async setThumbnail(broadcastId: BroadcastID, imagePath: string): Promise<void> {
 		const maxSize = 2 * 1024 * 1024;
-		let imageData: Buffer;
-		let mimeType: string;
 
+		// Only local files are supported: Companion cancels actions that run
+		// longer than ~5s, so downloading remote images isn't reliably possible.
 		if (imagePath.startsWith('http://') || imagePath.startsWith('https://')) {
-			const result = await this.#fetchImageFromUrl(imagePath);
-			imageData = result.data;
-			mimeType = result.mimeType;
-		} else {
-			const stat = await fs.stat(imagePath);
-			if (!stat) {
-				throw new Error(`Thumbnail file not found or inaccessible: ${imagePath}`);
-			}
-			if (stat.size > maxSize) {
-				throw new Error(`Thumbnail file too large: ${stat.size} bytes (max 2MB)`);
-			}
-
-			imageData = await fs.readFile(imagePath);
-			mimeType = this.#detectMimeType(imageData, imagePath);
+			throw new Error(
+				`Remote thumbnail URLs are not supported; provide a local file path to a JPEG/PNG image (got: ${imagePath})`
+			);
 		}
 
-		if (imageData.length > maxSize) {
-			throw new Error(`Thumbnail data too large: ${imageData.length} bytes (max 2MB)`);
+		const stat = await fs.stat(imagePath).catch(() => null);
+		if (!stat) {
+			throw new Error(`Thumbnail file not found or inaccessible: ${imagePath}`);
 		}
+		if (stat.size > maxSize) {
+			throw new Error(`Thumbnail file too large: ${stat.size} bytes (max 2MB)`);
+		}
+
+		const imageData = await fs.readFile(imagePath);
+		const mimeType = this.#detectMimeType(imageData, imagePath);
 
 		if (mimeType !== 'image/jpeg' && mimeType !== 'image/png') {
 			throw new Error(`Invalid thumbnail type: ${mimeType} (must be JPEG or PNG)`);
@@ -650,57 +644,6 @@ export class Core {
 		await this.YouTube.bindBroadcastToStream(broadcastId);
 		this.Module.log('info', `Unbound stream from broadcast ${broadcastId}`);
 		await this.reloadEverything();
-	}
-
-	async #fetchImageFromUrl(url: string, remainingRedirects = 5): Promise<{ data: Buffer; mimeType: string }> {
-		return new Promise((resolve, reject) => {
-			const protocol = url.startsWith('https://') ? https : http;
-
-			const request = protocol.get(url, { timeout: 30000 }, (response) => {
-				if (
-					response.statusCode &&
-					response.statusCode >= 300 &&
-					response.statusCode < 400 &&
-					response.headers.location
-				) {
-					if (remainingRedirects <= 0) {
-						reject(new Error('Too many redirects'));
-						return;
-					}
-					this.#fetchImageFromUrl(response.headers.location, remainingRedirects - 1)
-						.then(resolve)
-						.catch(reject);
-					return;
-				}
-
-				if (response.statusCode !== 200) {
-					reject(new Error(`Failed to fetch image: HTTP ${response.statusCode}`));
-					return;
-				}
-
-				const chunks: Buffer[] = [];
-				response.on('data', (chunk: Buffer) => chunks.push(chunk));
-				response.on('end', () => {
-					const data = Buffer.concat(chunks);
-					const contentType = response.headers['content-type'] || '';
-					let mimeType = contentType.split(';')[0].trim();
-
-					if (mimeType !== 'image/jpeg' && mimeType !== 'image/png') {
-						mimeType = this.#detectMimeType(data, url);
-					}
-
-					resolve({ data, mimeType });
-				});
-				response.on('error', reject);
-			});
-
-			request.on('timeout', () => {
-				request.destroy();
-				reject(new Error('Request timeout'));
-			});
-
-			request.on('error', reject);
-		});
 	}
 
 	#detectMimeType(data: Buffer, path: string): string {

--- a/src/feedbacks.test.ts
+++ b/src/feedbacks.test.ts
@@ -39,7 +39,14 @@ const SampleMemory: StateMemory = {
 			Health: StreamHealth.Good,
 		},
 	},
+	BoundStreams: {
+		abcd: {
+			Id: 'abcd',
+			Health: StreamHealth.Good,
+		},
+	},
 	UnfinishedBroadcasts: [],
+	LastCreatedBroadcast: null,
 };
 
 const SampleBroadcastCheck: CompanionFeedbackAdvancedEvent = {
@@ -103,7 +110,7 @@ async function tryBroadcast(phase: BroadcastLifecycle, core: Core): Promise<Comp
 
 async function tryStream(health: StreamHealth, core: Core): Promise<CompanionAdvancedFeedbackResult> {
 	await core.init();
-	core.Cache.Streams['abcd'].Health = health;
+	core.Cache.BoundStreams['abcd'].Health = health;
 	const feedbacks = listFeedbacks({ broadcasts: SampleMemory.Broadcasts, unfinishedCount: 0, core });
 	return feedbacks.broadcast_bound_stream_health.callback(SampleStreamCheck, SampleContext);
 }
@@ -202,7 +209,13 @@ describe('Broadcast lifecycle feedback', () => {
 	});
 
 	test('Unknown broadcasts', async () => {
-		const data: StateMemory = { Broadcasts: {}, Streams: {}, UnfinishedBroadcasts: [] };
+		const data: StateMemory = {
+			Broadcasts: {},
+			Streams: {},
+			BoundStreams: {},
+			UnfinishedBroadcasts: [],
+			LastCreatedBroadcast: null,
+		};
 		const event: CompanionFeedbackAdvancedEvent = {
 			id: 'abcd1234',
 			type: 'advanced',
@@ -227,7 +240,13 @@ describe('Broadcast lifecycle feedback', () => {
 	});
 
 	test('Events without ID', async () => {
-		const data: StateMemory = { Broadcasts: {}, Streams: {}, UnfinishedBroadcasts: [] };
+		const data: StateMemory = {
+			Broadcasts: {},
+			Streams: {},
+			BoundStreams: {},
+			UnfinishedBroadcasts: [],
+			LastCreatedBroadcast: null,
+		};
 		const event: CompanionFeedbackAdvancedEvent = {
 			id: 'abcd1234',
 			type: 'advanced',
@@ -321,7 +340,13 @@ describe('Stream health feedback', () => {
 	});
 
 	test('Unknown broadcasts', async () => {
-		const data: StateMemory = { Broadcasts: {}, Streams: {}, UnfinishedBroadcasts: [] };
+		const data: StateMemory = {
+			Broadcasts: {},
+			Streams: {},
+			BoundStreams: {},
+			UnfinishedBroadcasts: [],
+			LastCreatedBroadcast: null,
+		};
 		const event: CompanionFeedbackAdvancedEvent = {
 			id: 'abcd1234',
 			type: 'advanced',
@@ -362,7 +387,9 @@ describe('Stream health feedback', () => {
 				},
 			},
 			Streams: {},
+			BoundStreams: {},
 			UnfinishedBroadcasts: [],
+			LastCreatedBroadcast: null,
 		};
 
 		const event: CompanionFeedbackAdvancedEvent = {
@@ -389,7 +416,13 @@ describe('Stream health feedback', () => {
 	});
 
 	test('Events without ID', async () => {
-		const data: StateMemory = { Broadcasts: {}, Streams: {}, UnfinishedBroadcasts: [] };
+		const data: StateMemory = {
+			Broadcasts: {},
+			Streams: {},
+			BoundStreams: {},
+			UnfinishedBroadcasts: [],
+			LastCreatedBroadcast: null,
+		};
 		const event: CompanionFeedbackAdvancedEvent = {
 			id: 'abcd1234',
 			type: 'advanced',

--- a/src/feedbacks.test.ts
+++ b/src/feedbacks.test.ts
@@ -42,7 +42,14 @@ const SampleMemory: StateMemory = {
 			Health: StreamHealth.Good,
 		},
 	},
+	BoundStreams: {
+		abcd: {
+			Id: 'abcd',
+			Health: StreamHealth.Good,
+		},
+	},
 	UnfinishedBroadcasts: [],
+	LastCreatedBroadcast: null,
 };
 
 const SampleBroadcastCheck: CompanionFeedbackAdvancedEvent = {
@@ -106,7 +113,7 @@ async function tryBroadcast(phase: BroadcastLifecycle, core: Core): Promise<Comp
 
 async function tryStream(health: StreamHealth, core: Core): Promise<CompanionAdvancedFeedbackResult> {
 	await core.init();
-	core.Cache.Streams['abcd'].Health = health;
+	core.Cache.BoundStreams['abcd'].Health = health;
 	const feedbacks = listFeedbacks({ broadcasts: SampleMemory.Broadcasts, unfinishedCount: 0, core });
 	return feedbacks.broadcast_bound_stream_health.callback(SampleStreamCheck, SampleContext);
 }
@@ -205,7 +212,13 @@ describe('Broadcast lifecycle feedback', () => {
 	});
 
 	test('Unknown broadcasts', async () => {
-		const data: StateMemory = { Broadcasts: {}, Streams: {}, UnfinishedBroadcasts: [] };
+		const data: StateMemory = {
+			Broadcasts: {},
+			Streams: {},
+			BoundStreams: {},
+			UnfinishedBroadcasts: [],
+			LastCreatedBroadcast: null,
+		};
 		const event: CompanionFeedbackAdvancedEvent = {
 			id: 'abcd1234',
 			type: 'advanced',
@@ -230,7 +243,13 @@ describe('Broadcast lifecycle feedback', () => {
 	});
 
 	test('Events without ID', async () => {
-		const data: StateMemory = { Broadcasts: {}, Streams: {}, UnfinishedBroadcasts: [] };
+		const data: StateMemory = {
+			Broadcasts: {},
+			Streams: {},
+			BoundStreams: {},
+			UnfinishedBroadcasts: [],
+			LastCreatedBroadcast: null,
+		};
 		const event: CompanionFeedbackAdvancedEvent = {
 			id: 'abcd1234',
 			type: 'advanced',
@@ -324,7 +343,13 @@ describe('Stream health feedback', () => {
 	});
 
 	test('Unknown broadcasts', async () => {
-		const data: StateMemory = { Broadcasts: {}, Streams: {}, UnfinishedBroadcasts: [] };
+		const data: StateMemory = {
+			Broadcasts: {},
+			Streams: {},
+			BoundStreams: {},
+			UnfinishedBroadcasts: [],
+			LastCreatedBroadcast: null,
+		};
 		const event: CompanionFeedbackAdvancedEvent = {
 			id: 'abcd1234',
 			type: 'advanced',
@@ -366,7 +391,9 @@ describe('Stream health feedback', () => {
 				},
 			},
 			Streams: {},
+			BoundStreams: {},
 			UnfinishedBroadcasts: [],
+			LastCreatedBroadcast: null,
 		};
 
 		const event: CompanionFeedbackAdvancedEvent = {
@@ -393,7 +420,13 @@ describe('Stream health feedback', () => {
 	});
 
 	test('Events without ID', async () => {
-		const data: StateMemory = { Broadcasts: {}, Streams: {}, UnfinishedBroadcasts: [] };
+		const data: StateMemory = {
+			Broadcasts: {},
+			Streams: {},
+			BoundStreams: {},
+			UnfinishedBroadcasts: [],
+			LastCreatedBroadcast: null,
+		};
 		const event: CompanionFeedbackAdvancedEvent = {
 			id: 'abcd1234',
 			type: 'advanced',

--- a/src/feedbacks.test.ts
+++ b/src/feedbacks.test.ts
@@ -40,12 +40,14 @@ const SampleMemory: StateMemory = {
 		abcd: {
 			Id: 'abcd',
 			Health: StreamHealth.Good,
+			Name: null,
 		},
 	},
 	BoundStreams: {
 		abcd: {
 			Id: 'abcd',
 			Health: StreamHealth.Good,
+			Name: null,
 		},
 	},
 	UnfinishedBroadcasts: [],

--- a/src/feedbacks.ts
+++ b/src/feedbacks.ts
@@ -281,11 +281,11 @@ export function listFeedbacks({
 					}
 
 					const streamId = broadcast.BoundStreamId;
-					if (!(streamId in core.Cache.Streams)) {
+					if (!(streamId in core.Cache.BoundStreams)) {
 						return {};
 					}
 
-					stream = core.Cache.Streams[streamId];
+					stream = core.Cache.BoundStreams[streamId];
 					broadcastStatus = broadcast.Status;
 				}
 

--- a/src/feedbacks.ts
+++ b/src/feedbacks.ts
@@ -283,11 +283,11 @@ export function listFeedbacks({
 					}
 
 					const streamId = broadcast.BoundStreamId;
-					if (!(streamId in core.Cache.Streams)) {
+					if (!(streamId in core.Cache.BoundStreams)) {
 						return {};
 					}
 
-					stream = core.Cache.Streams[streamId];
+					stream = core.Cache.BoundStreams[streamId];
 					broadcastStatus = broadcast.Status;
 				}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -223,6 +223,7 @@ export class YoutubeInstance extends InstanceBase<RawConfig, RawSecrets> impleme
 				broadcasts: memory.Broadcasts,
 				unfinishedCount: unfinishedCnt,
 				core: this.#core,
+				streams: memory.Streams,
 			})
 		);
 		this.setPresetDefinitions(listPresets(() => ({ broadcasts: memory.Broadcasts, unfinishedCount: unfinishedCnt })));

--- a/src/vars.test.ts
+++ b/src/vars.test.ts
@@ -28,6 +28,8 @@ const SampleMemory: StateMemory = {
 		},
 	},
 	UnfinishedBroadcasts: [],
+	BoundStreams: {},
+	LastCreatedBroadcast: null,
 };
 
 function hasAny(vars: CompanionVariableDefinition[] | VariableContent[], name: string): boolean {
@@ -41,10 +43,17 @@ function hasAny(vars: CompanionVariableDefinition[] | VariableContent[], name: s
 }
 
 describe('Variable declarations', () => {
-	test('No variables without broadcasts', () => {
-		const data: StateMemory = { Broadcasts: {}, Streams: {}, UnfinishedBroadcasts: [] };
+	test('Only global variable without broadcasts', () => {
+		const data: StateMemory = {
+			Broadcasts: {},
+			Streams: {},
+			BoundStreams: {},
+			UnfinishedBroadcasts: [],
+			LastCreatedBroadcast: null,
+		};
 		const result = declareVars(data, 0);
-		expect(result).toHaveLength(0);
+		expect(result).toHaveLength(1);
+		expect(result[0]).toEqual(expect.objectContaining({ variableId: 'last_created_broadcast_id' }));
 	});
 
 	test('Lifecycle and health added for each broadcast', () => {
@@ -113,10 +122,17 @@ describe('Variable declarations', () => {
 });
 
 describe('Variable values', () => {
-	test('No variables without broadcasts', () => {
-		const data: StateMemory = { Broadcasts: {}, Streams: {}, UnfinishedBroadcasts: [] };
+	test('Only global variable without broadcasts', () => {
+		const data: StateMemory = {
+			Broadcasts: {},
+			Streams: {},
+			BoundStreams: {},
+			UnfinishedBroadcasts: [],
+			LastCreatedBroadcast: null,
+		};
 		const result = exportVars(data, 0);
-		expect(result).toHaveLength(0);
+		expect(result).toHaveLength(1);
+		expect(result[0]).toEqual({ name: 'last_created_broadcast_id', value: '' });
 	});
 
 	test('Lifecycle and health added for each broadcast', () => {

--- a/src/vars.test.ts
+++ b/src/vars.test.ts
@@ -28,6 +28,7 @@ const SampleMemory: StateMemory = {
 		streamID: {
 			Id: 'streamID',
 			Health: StreamHealth.Good,
+			Name: null,
 		},
 	},
 	UnfinishedBroadcasts: [],

--- a/src/vars.test.ts
+++ b/src/vars.test.ts
@@ -31,6 +31,8 @@ const SampleMemory: StateMemory = {
 		},
 	},
 	UnfinishedBroadcasts: [],
+	BoundStreams: {},
+	LastCreatedBroadcast: null,
 };
 
 function hasAny(vars: CompanionVariableDefinition[] | VariableContent[], name: string): boolean {
@@ -44,10 +46,17 @@ function hasAny(vars: CompanionVariableDefinition[] | VariableContent[], name: s
 }
 
 describe('Variable declarations', () => {
-	test('No variables without broadcasts', () => {
-		const data: StateMemory = { Broadcasts: {}, Streams: {}, UnfinishedBroadcasts: [] };
+	test('Only global variable without broadcasts', () => {
+		const data: StateMemory = {
+			Broadcasts: {},
+			Streams: {},
+			BoundStreams: {},
+			UnfinishedBroadcasts: [],
+			LastCreatedBroadcast: null,
+		};
 		const result = declareVars(data, 0);
-		expect(result).toHaveLength(0);
+		expect(result).toHaveLength(1);
+		expect(result[0]).toEqual(expect.objectContaining({ variableId: 'last_created_broadcast_id' }));
 	});
 
 	test('Lifecycle, health, visibility added for each broadcast', () => {
@@ -132,10 +141,17 @@ describe('Variable declarations', () => {
 });
 
 describe('Variable values', () => {
-	test('No variables without broadcasts', () => {
-		const data: StateMemory = { Broadcasts: {}, Streams: {}, UnfinishedBroadcasts: [] };
+	test('Only global variable without broadcasts', () => {
+		const data: StateMemory = {
+			Broadcasts: {},
+			Streams: {},
+			BoundStreams: {},
+			UnfinishedBroadcasts: [],
+			LastCreatedBroadcast: null,
+		};
 		const result = exportVars(data, 0);
-		expect(result).toHaveLength(0);
+		expect(result).toHaveLength(1);
+		expect(result[0]).toEqual({ name: 'last_created_broadcast_id', value: '' });
 	});
 
 	test('Lifecycle, health, visibility added for each broadcast', () => {

--- a/src/vars.ts
+++ b/src/vars.ts
@@ -30,6 +30,8 @@ export function declareVars(memory: StateMemory, unfinishedCnt: number): Compani
 		});
 	});
 
+	result.push({ variableId: 'last_created_broadcast_id', name: 'ID of the most recently created broadcast' });
+
 	Array(unfinishedCnt)
 		.keys()
 		.forEach((i) => {
@@ -53,6 +55,8 @@ export function declareVars(memory: StateMemory, unfinishedCnt: number): Compani
  */
 export function exportVars(memory: StateMemory, unfinishedCnt: number): VariableContent[] {
 	const result: VariableContent[] = [];
+
+	result.push({ name: 'last_created_broadcast_id', value: memory.LastCreatedBroadcast?.Id || '' });
 
 	Object.values(memory.Broadcasts).forEach((broadcast) => {
 		result.push(...getBroadcastVars(broadcast));

--- a/src/vars.ts
+++ b/src/vars.ts
@@ -38,6 +38,8 @@ export function declareVars(memory: StateMemory, unfinishedCnt: number): Compani
 		);
 	});
 
+	result.push({ variableId: 'last_created_broadcast_id', name: 'ID of the most recently created broadcast' });
+
 	Array(unfinishedCnt)
 		.keys()
 		.forEach((i) => {
@@ -65,6 +67,8 @@ export function declareVars(memory: StateMemory, unfinishedCnt: number): Compani
  */
 export function exportVars(memory: StateMemory, unfinishedCnt: number): VariableContent[] {
 	const result: VariableContent[] = [];
+
+	result.push({ name: 'last_created_broadcast_id', value: memory.LastCreatedBroadcast?.Id || '' });
 
 	Object.values(memory.Broadcasts).forEach((broadcast) => {
 		result.push(...getBroadcastVars(broadcast));

--- a/src/youtube.test.ts
+++ b/src/youtube.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 //require("leaked-handles");
 import type { OAuth2Client } from 'google-auth-library';
-import { YoutubeConnector, Transition } from './youtube.js';
+import { YoutubeConnector, Transition, Visibility } from './youtube.js';
 import type { FakeYouTube } from './__tests__/mock/fake-youtube.js';
 import { type StateMemory, BroadcastLifecycle, StreamHealth } from './cache.js';
 vi.mock('@googleapis/youtube', async () => {
@@ -61,6 +61,8 @@ const memory: StateMemory = {
 		},
 	},
 	UnfinishedBroadcasts: [],
+	BoundStreams: {},
+	LastCreatedBroadcast: null,
 };
 
 const memoryUpdated: StateMemory = {
@@ -92,6 +94,8 @@ const memoryUpdated: StateMemory = {
 	},
 	Streams: {},
 	UnfinishedBroadcasts: [],
+	BoundStreams: {},
+	LastCreatedBroadcast: null,
 };
 
 describe('Queries', () => {
@@ -481,5 +485,96 @@ describe('Set description', () => {
 			instance.setDescription('bB', '2022-22-22T21:21:21', 'Broadcast B', 'Test description')
 		).rejects.toBeInstanceOf(Error);
 		expect(mock.liveBroadcasts.update).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe('Create broadcast', () => {
+	beforeEach(() => {
+		vi.resetAllMocks();
+	});
+
+	test('success', async () => {
+		mock.liveBroadcasts.insert.mockImplementation(async () => {
+			return Promise.resolve({
+				data: { id: 'newBroadcast123' },
+			});
+		});
+		const result = await instance.createBroadcast(
+			'Test Title',
+			'2024-01-01T00:00:00Z',
+			Visibility.Private,
+			'Test description',
+			true,
+			false,
+			true
+		);
+		expect(result).toBe('newBroadcast123');
+		expect(mock.liveBroadcasts.insert).toHaveBeenCalledTimes(1);
+	});
+
+	test('failure - no ID returned', async () => {
+		mock.liveBroadcasts.insert.mockImplementation(async () => {
+			return Promise.resolve({
+				data: { id: null },
+			});
+		});
+		await expect(instance.createBroadcast('Test', '2024-01-01T00:00:00Z', Visibility.Private)).rejects.toThrowError(
+			'Failed to create broadcast: no ID returned'
+		);
+	});
+});
+
+describe('List streams', () => {
+	beforeEach(() => {
+		vi.resetAllMocks();
+	});
+
+	test('success', async () => {
+		mock.liveStreams.list.mockImplementation(async () => {
+			return Promise.resolve({
+				data: {
+					items: [
+						{
+							id: 'stream1',
+							snippet: { title: 'My Stream' },
+							status: { healthStatus: { status: 'good' } },
+						},
+						{
+							id: 'stream2',
+							snippet: { title: undefined },
+							status: { healthStatus: { status: 'noData' } },
+						},
+					],
+				},
+			});
+		});
+		const result = await instance.listStreams();
+		expect(result).toStrictEqual({
+			stream1: { Id: 'stream1', Health: StreamHealth.Good, Name: 'My Stream' },
+			stream2: { Id: 'stream2', Health: StreamHealth.NoData, Name: undefined },
+		});
+		expect(mock.liveStreams.list).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe('Bind broadcast to stream', () => {
+	beforeEach(() => {
+		vi.resetAllMocks();
+	});
+
+	test('bind success', async () => {
+		mock.liveBroadcasts.bind.mockImplementation(async () => {
+			return Promise.resolve();
+		});
+		await expect(instance.bindBroadcastToStream('bA', 'sA')).resolves.toBeUndefined();
+		expect(mock.liveBroadcasts.bind).toHaveBeenCalledTimes(1);
+	});
+
+	test('unbind success', async () => {
+		mock.liveBroadcasts.bind.mockImplementation(async () => {
+			return Promise.resolve();
+		});
+		await expect(instance.bindBroadcastToStream('bA')).resolves.toBeUndefined();
+		expect(mock.liveBroadcasts.bind).toHaveBeenCalledTimes(1);
 	});
 });

--- a/src/youtube.test.ts
+++ b/src/youtube.test.ts
@@ -66,6 +66,8 @@ const memory: StateMemory = {
 		},
 	},
 	UnfinishedBroadcasts: [],
+	BoundStreams: {},
+	LastCreatedBroadcast: null,
 };
 
 const memoryUpdated: StateMemory = {
@@ -99,6 +101,8 @@ const memoryUpdated: StateMemory = {
 	},
 	Streams: {},
 	UnfinishedBroadcasts: [],
+	BoundStreams: {},
+	LastCreatedBroadcast: null,
 };
 
 describe('Queries', () => {
@@ -488,5 +492,96 @@ describe('Set description', () => {
 			instance.setDescription('bB', '2022-22-22T21:21:21', 'Broadcast B', 'Test description')
 		).rejects.toBeInstanceOf(Error);
 		expect(mock.liveBroadcasts.update).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe('Create broadcast', () => {
+	beforeEach(() => {
+		vi.resetAllMocks();
+	});
+
+	test('success', async () => {
+		mock.liveBroadcasts.insert.mockImplementation(async () => {
+			return Promise.resolve({
+				data: { id: 'newBroadcast123' },
+			});
+		});
+		const result = await instance.createBroadcast(
+			'Test Title',
+			'2024-01-01T00:00:00Z',
+			Visibility.Private,
+			'Test description',
+			true,
+			false,
+			true
+		);
+		expect(result).toBe('newBroadcast123');
+		expect(mock.liveBroadcasts.insert).toHaveBeenCalledTimes(1);
+	});
+
+	test('failure - no ID returned', async () => {
+		mock.liveBroadcasts.insert.mockImplementation(async () => {
+			return Promise.resolve({
+				data: { id: null },
+			});
+		});
+		await expect(instance.createBroadcast('Test', '2024-01-01T00:00:00Z', Visibility.Private)).rejects.toThrowError(
+			'Failed to create broadcast: no ID returned'
+		);
+	});
+});
+
+describe('List streams', () => {
+	beforeEach(() => {
+		vi.resetAllMocks();
+	});
+
+	test('success', async () => {
+		mock.liveStreams.list.mockImplementation(async () => {
+			return Promise.resolve({
+				data: {
+					items: [
+						{
+							id: 'stream1',
+							snippet: { title: 'My Stream' },
+							status: { healthStatus: { status: 'good' } },
+						},
+						{
+							id: 'stream2',
+							snippet: { title: undefined },
+							status: { healthStatus: { status: 'noData' } },
+						},
+					],
+				},
+			});
+		});
+		const result = await instance.listStreams();
+		expect(result).toStrictEqual({
+			stream1: { Id: 'stream1', Health: StreamHealth.Good, Name: 'My Stream' },
+			stream2: { Id: 'stream2', Health: StreamHealth.NoData, Name: undefined },
+		});
+		expect(mock.liveStreams.list).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe('Bind broadcast to stream', () => {
+	beforeEach(() => {
+		vi.resetAllMocks();
+	});
+
+	test('bind success', async () => {
+		mock.liveBroadcasts.bind.mockImplementation(async () => {
+			return Promise.resolve();
+		});
+		await expect(instance.bindBroadcastToStream('bA', 'sA')).resolves.toBeUndefined();
+		expect(mock.liveBroadcasts.bind).toHaveBeenCalledTimes(1);
+	});
+
+	test('unbind success', async () => {
+		mock.liveBroadcasts.bind.mockImplementation(async () => {
+			return Promise.resolve();
+		});
+		await expect(instance.bindBroadcastToStream('bA')).resolves.toBeUndefined();
+		expect(mock.liveBroadcasts.bind).toHaveBeenCalledTimes(1);
 	});
 });

--- a/src/youtube.test.ts
+++ b/src/youtube.test.ts
@@ -59,10 +59,12 @@ const memory: StateMemory = {
 		sA: {
 			Id: 'sA',
 			Health: StreamHealth.Good,
+			Name: null,
 		},
 		sB: {
 			Id: 'sB',
 			Health: StreamHealth.Bad,
+			Name: null,
 		},
 	},
 	UnfinishedBroadcasts: [],
@@ -558,7 +560,7 @@ describe('List streams', () => {
 		const result = await instance.listStreams();
 		expect(result).toStrictEqual({
 			stream1: { Id: 'stream1', Health: StreamHealth.Good, Name: 'My Stream' },
-			stream2: { Id: 'stream2', Health: StreamHealth.NoData, Name: undefined },
+			stream2: { Id: 'stream2', Health: StreamHealth.NoData, Name: null },
 		});
 		expect(mock.liveStreams.list).toHaveBeenCalledTimes(1);
 	});

--- a/src/youtube.test.ts
+++ b/src/youtube.test.ts
@@ -508,15 +508,15 @@ describe('Create broadcast', () => {
 				data: { id: 'newBroadcast123' },
 			});
 		});
-		const result = await instance.createBroadcast(
-			'Test Title',
-			'2024-01-01T00:00:00Z',
-			Visibility.Private,
-			'Test description',
-			true,
-			false,
-			true
-		);
+		const result = await instance.createBroadcast({
+			title: 'Test Title',
+			scheduledStartTime: '2024-01-01T00:00:00Z',
+			privacyStatus: Visibility.Private,
+			description: 'Test description',
+			enableAutoStart: true,
+			enableAutoStop: false,
+			enableMonitorStream: true,
+		});
 		expect(result).toBe('newBroadcast123');
 		expect(mock.liveBroadcasts.insert).toHaveBeenCalledTimes(1);
 	});
@@ -527,9 +527,13 @@ describe('Create broadcast', () => {
 				data: { id: null },
 			});
 		});
-		await expect(instance.createBroadcast('Test', '2024-01-01T00:00:00Z', Visibility.Private)).rejects.toThrowError(
-			'Failed to create broadcast: no ID returned'
-		);
+		await expect(
+			instance.createBroadcast({
+				title: 'Test',
+				scheduledStartTime: '2024-01-01T00:00:00Z',
+				privacyStatus: Visibility.Private,
+			})
+		).rejects.toThrowError('Failed to create broadcast: no ID returned');
 	});
 });
 

--- a/src/youtube.test.ts
+++ b/src/youtube.test.ts
@@ -59,7 +59,7 @@ const memory: StateMemory = {
 		sA: {
 			Id: 'sA',
 			Health: StreamHealth.Good,
-			Name: null,
+			Name: 'Stream A',
 		},
 		sB: {
 			Id: 'sB',
@@ -268,6 +268,7 @@ describe('Queries', () => {
 	test('get bound streams', async () => {
 		mock.liveStreams.list.mockImplementation(async ({ part, id: localID }) => {
 			expect(part).toContain('status');
+			expect(part).toContain('snippet');
 			expect(localID).toHaveLength(2);
 			Object.values(memory.Streams).forEach((item) => {
 				expect(localID).toContain(item.Id);
@@ -275,7 +276,7 @@ describe('Queries', () => {
 			return Promise.resolve({
 				data: {
 					items: [
-						{ id: 'sA', status: { healthStatus: { status: 'good' } } },
+						{ id: 'sA', snippet: { title: 'Stream A' }, status: { healthStatus: { status: 'good' } } },
 						{ id: 'sB', status: { healthStatus: { status: 'bad' } } },
 					],
 				},

--- a/src/youtube.ts
+++ b/src/youtube.ts
@@ -22,6 +22,16 @@ function broadcastVisibility(broadcast: youtube_v3.Schema$LiveBroadcast): Visibi
 	return privacyStatus ? (privacyStatus as Visibility) : Visibility.Private;
 }
 
+export interface CreateYouTubeBroadcastParameters {
+	title: string;
+	scheduledStartTime: string;
+	privacyStatus: Visibility;
+	description?: string;
+	enableAutoStart?: boolean;
+	enableAutoStop?: boolean;
+	enableMonitorStream?: boolean;
+}
+
 export interface YoutubeAPI {
 	/**
 	 * Fetch known broadcasts (limited by max count)
@@ -106,15 +116,15 @@ export interface YoutubeAPI {
 	 * @param enableMonitorStream Whether to enable the monitor stream
 	 * @returns ID of the created broadcast
 	 */
-	createBroadcast(
-		title: string,
-		scheduledStartTime: string,
-		privacyStatus: Visibility,
-		description?: string,
-		enableAutoStart?: boolean,
-		enableAutoStop?: boolean,
-		enableMonitorStream?: boolean
-	): Promise<BroadcastID>;
+	createBroadcast({
+		title,
+		scheduledStartTime,
+		privacyStatus,
+		description,
+		enableAutoStart,
+		enableAutoStop,
+		enableMonitorStream,
+	}: CreateYouTubeBroadcastParameters): Promise<BroadcastID>;
 
 	/**
 	 * Upload and set a custom thumbnail for a broadcast/video
@@ -408,15 +418,15 @@ export class YoutubeConnector implements YoutubeAPI {
 	/**
 	 * @inheritdoc
 	 */
-	async createBroadcast(
-		title: string,
-		scheduledStartTime: string,
-		privacyStatus: Visibility,
-		description?: string,
-		enableAutoStart?: boolean,
-		enableAutoStop?: boolean,
-		enableMonitorStream?: boolean
-	): Promise<BroadcastID> {
+	async createBroadcast({
+		title,
+		scheduledStartTime,
+		privacyStatus,
+		description,
+		enableAutoStart,
+		enableAutoStop,
+		enableMonitorStream,
+	}: CreateYouTubeBroadcastParameters): Promise<BroadcastID> {
 		const response = await this.ApiClient.liveBroadcasts.insert({
 			part: ['snippet', 'status', 'contentDetails'],
 			requestBody: {

--- a/src/youtube.ts
+++ b/src/youtube.ts
@@ -22,6 +22,8 @@ function broadcastVisibility(broadcast: youtube_v3.Schema$LiveBroadcast): Visibi
 	return privacyStatus ? (privacyStatus as Visibility) : Visibility.Private;
 }
 
+type ImageMimeType = 'image/png' | 'image/jpeg';
+
 export interface CreateYouTubeBroadcastParameters {
 	title: string;
 	scheduledStartTime: string;
@@ -132,7 +134,7 @@ export interface YoutubeAPI {
 	 * @param imageData Buffer containing the image data
 	 * @param mimeType MIME type of the image (image/jpeg or image/png)
 	 */
-	setThumbnail(broadcastId: BroadcastID, imageData: Buffer, mimeType: string): Promise<void>;
+	setThumbnail(broadcastId: BroadcastID, imageData: Buffer, mimeType: ImageMimeType): Promise<void>;
 
 	/**
 	 * List all streams for the authenticated user
@@ -459,7 +461,7 @@ export class YoutubeConnector implements YoutubeAPI {
 	/**
 	 * @inheritdoc
 	 */
-	async setThumbnail(broadcastId: BroadcastID, imageData: Buffer, mimeType: string): Promise<void> {
+	async setThumbnail(broadcastId: BroadcastID, imageData: Buffer, mimeType: ImageMimeType): Promise<void> {
 		await this.ApiClient.thumbnails.set({
 			videoId: broadcastId,
 			media: {

--- a/src/youtube.ts
+++ b/src/youtube.ts
@@ -1,3 +1,4 @@
+import { Readable } from 'node:stream';
 import type { OAuth2Client } from 'google-auth-library';
 import { youtube, type youtube_v3 } from '@googleapis/youtube';
 import type { Broadcast, BroadcastMap, StreamMap } from './cache.js';
@@ -93,6 +94,48 @@ export interface YoutubeAPI {
 	 * @param visibility Visibility of the broadcast
 	 */
 	setVisibility(id: BroadcastID, visibility: Visibility): Promise<void>;
+
+	/**
+	 * Create a new broadcast
+	 * @param title Title of the broadcast (1-100 chars)
+	 * @param scheduledStartTime ISO 8601 formatted start time
+	 * @param privacyStatus Privacy status of the broadcast
+	 * @param description Optional description (max 5000 chars)
+	 * @param enableAutoStart Whether to automatically start when stream becomes active
+	 * @param enableAutoStop Whether to automatically stop when stream becomes inactive
+	 * @param enableMonitorStream Whether to enable the monitor stream
+	 * @returns ID of the created broadcast
+	 */
+	createBroadcast(
+		title: string,
+		scheduledStartTime: string,
+		privacyStatus: Visibility,
+		description?: string,
+		enableAutoStart?: boolean,
+		enableAutoStop?: boolean,
+		enableMonitorStream?: boolean
+	): Promise<BroadcastID>;
+
+	/**
+	 * Upload and set a custom thumbnail for a broadcast/video
+	 * @param broadcastId The broadcast (video) ID
+	 * @param imageData Buffer containing the image data
+	 * @param mimeType MIME type of the image (image/jpeg or image/png)
+	 */
+	setThumbnail(broadcastId: BroadcastID, imageData: Buffer, mimeType: string): Promise<void>;
+
+	/**
+	 * List all streams for the authenticated user
+	 * @returns Map of available streams
+	 */
+	listStreams(): Promise<StreamMap>;
+
+	/**
+	 * Bind a broadcast to a stream (or unbind by omitting streamId)
+	 * @param broadcastId Broadcast ID to bind
+	 * @param streamId Stream ID to bind to (omit to unbind)
+	 */
+	bindBroadcastToStream(broadcastId: BroadcastID, streamId?: string): Promise<void>;
 }
 
 /**
@@ -357,6 +400,97 @@ export class YoutubeConnector implements YoutubeAPI {
 					privacyStatus: visibility,
 				},
 			},
+		});
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	async createBroadcast(
+		title: string,
+		scheduledStartTime: string,
+		privacyStatus: Visibility,
+		description?: string,
+		enableAutoStart?: boolean,
+		enableAutoStop?: boolean,
+		enableMonitorStream?: boolean
+	): Promise<BroadcastID> {
+		const response = await this.ApiClient.liveBroadcasts.insert({
+			part: ['snippet', 'status', 'contentDetails'],
+			requestBody: {
+				snippet: {
+					title,
+					scheduledStartTime,
+					description,
+				},
+				status: {
+					privacyStatus,
+				},
+				contentDetails: {
+					enableAutoStart: enableAutoStart ?? false,
+					enableAutoStop: enableAutoStop ?? false,
+					monitorStream: {
+						enableMonitorStream: enableMonitorStream ?? true,
+					},
+				},
+			},
+		});
+
+		const id = response.data.id;
+		if (!id) {
+			throw new Error('Failed to create broadcast: no ID returned');
+		}
+
+		return id;
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	async setThumbnail(broadcastId: BroadcastID, imageData: Buffer, mimeType: string): Promise<void> {
+		await this.ApiClient.thumbnails.set({
+			videoId: broadcastId,
+			media: {
+				mimeType,
+				body: Readable.from(imageData),
+			},
+		});
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	async listStreams(): Promise<StreamMap> {
+		const response = await this.ApiClient.liveStreams.list({
+			part: ['id', 'snippet', 'status'],
+			mine: true,
+			maxResults: 50,
+		});
+
+		const mapping: StreamMap = {};
+
+		response.data.items?.forEach((item) => {
+			const id = item.id!;
+			const health = item.status!.healthStatus!.status! as StreamHealth;
+
+			mapping[id] = {
+				Id: id,
+				Health: health,
+				Name: item.snippet?.title ?? undefined,
+			};
+		});
+
+		return mapping;
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	async bindBroadcastToStream(broadcastId: BroadcastID, streamId?: string): Promise<void> {
+		await this.ApiClient.liveBroadcasts.bind({
+			part: ['id'],
+			id: broadcastId,
+			streamId,
 		});
 	}
 }

--- a/src/youtube.ts
+++ b/src/youtube.ts
@@ -299,10 +299,12 @@ export class YoutubeConnector implements YoutubeAPI {
 		response.data.items?.forEach((item) => {
 			const id = item.id!;
 			const health = item.status!.healthStatus!.status! as StreamHealth;
+			const name = item.snippet?.title ?? null;
 
 			mapping[id] = {
 				Id: id,
 				Health: health,
+				Name: name,
 			};
 		});
 
@@ -476,7 +478,7 @@ export class YoutubeConnector implements YoutubeAPI {
 			mapping[id] = {
 				Id: id,
 				Health: health,
-				Name: item.snippet?.title ?? undefined,
+				Name: item.snippet?.title ?? null,
 			};
 		});
 

--- a/src/youtube.ts
+++ b/src/youtube.ts
@@ -110,7 +110,7 @@ export interface YoutubeAPI {
 	/**
 	 * Create a new broadcast
 	 * @param title Title of the broadcast (1-100 chars)
-	 * @param scheduledStartTime ISO 8601 formatted start time
+	 * @param scheduledStartTime ISO 8601-formatted (`YYYY-MM-DDThh:mm:ss.sZ`) start time
 	 * @param privacyStatus Privacy status of the broadcast
 	 * @param description Optional description (max 5000 chars)
 	 * @param enableAutoStart Whether to automatically start when stream becomes active

--- a/src/youtube.ts
+++ b/src/youtube.ts
@@ -301,7 +301,7 @@ export class YoutubeConnector implements YoutubeAPI {
 		const streamIds = Array.from(new Set(Object.values(broadcasts).map((broadcast) => broadcast.BoundStreamId)));
 
 		const response = await this.ApiClient.liveStreams.list({
-			part: ['status'],
+			part: ['snippet', 'status'],
 			id: streamIds as Array<string>,
 			maxResults: this.MaxBroadcasts,
 		});


### PR DESCRIPTION
Add create broadcast action with title, description, visibility, scheduled start time, auto-start/stop, monitor stream, thumbnail, and stream binding options. Add standalone set thumbnail and bind/unbind stream actions.

Add `last_created_broadcast_id` variable, available streams cache with `listStreams` API, and update HELP.md documentation.

Closes #149 

<img width="600" alt="Create new broadcast" src="https://github.com/user-attachments/assets/bd176e2d-1b4f-435c-b05f-5b3f3707def1" />
<img width="600" alt="Set broadcast thumbnail and Bind stream to broadcast" src="https://github.com/user-attachments/assets/19ca5fd6-c574-41ed-8671-e3ecf260ceb9" />
