### PR TITLE
Add clear explicit instruction to click the llink to initiate auth

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -293,7 +293,7 @@ export function listConfigFields(instance: Pick<YoutubeInstance, 'label'>): Some
 <p>Then, and whenever YouTube requires you to reauthenticate:</p>
 
 <ol>
-	<li><a href="./instance/${instance.label}/authorize" target="_blank">Consent
+	<li>Click on this link to <a href="./instance/${instance.label}/authorize" target="_blank">Consent
 	  to YouTube letting Companion operate your broadcasts</a> using a Google
 	  account and selecting your channel.  (The full consent URL is also logged
 	  in connection logs when you click that link.)</li>


### PR DESCRIPTION
Suggested resolution for Issue #168.

The authentication step used to be automatic after saving changes to the configuration for the connection. Now the user has to guess that clicking on the link in the configuration is required to initiate the autentication step. I'm suggesting that requirement be clearly shed in the instructions.