### PR TITLE
Expose broadcast description as a Companion variable

### DIFF
--- a/src/vars.test.ts
+++ b/src/vars.test.ts
@@ -76,6 +76,14 @@ describe('Variable declarations', () => {
 				}),
 			])
 		);
+
+		expect(result).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					variableId: 'broadcast_broadcastID_description',
+				}),
+			])
+		);
 	});
 
 	test('Unfinished variables added for each unfinished broadcast', () => {
@@ -138,11 +146,26 @@ describe('Variable values', () => {
 		expect(result).toHaveLength(0);
 	});
 
-	test('Lifecycle, health, visibility added for each broadcast', () => {
+	test('Lifecycle, health, visibility, description added for each broadcast', () => {
 		const result = exportVars(SampleMemory, 1);
 		expect(hasAny(result, 'broadcast_broadcastID_lifecycle')).toBeTruthy();
 		expect(hasAny(result, 'broadcast_broadcastID_health')).toBeTruthy();
 		expect(hasAny(result, 'broadcast_broadcastID_visibility')).toBeTruthy();
+		expect(hasAny(result, 'broadcast_broadcastID_description')).toBeTruthy();
+	});
+
+	test('Broadcast description is exported', () => {
+		const data = clone(SampleMemory);
+		data.Broadcasts.broadcastID.Description = 'Test description';
+		const result = getBroadcastVars(data.Broadcasts.broadcastID);
+		expect(result).toEqual(
+			expect.arrayContaining([
+									{
+										name: 'broadcast_broadcastID_description',
+										value: 'Test description',
+									},
+			])
+		);
 	});
 
 	test('Broadcasts without bound stream are handled', () => {

--- a/src/vars.ts
+++ b/src/vars.ts
@@ -34,7 +34,11 @@ export function declareVars(memory: StateMemory, unfinishedCnt: number): Compani
 			{
 				variableId: `broadcast_${item.Id}_visibility`,
 				name: `Visibility of the stream bound to broadcast titled '${item.Name}'`,
-			}
+			},
+			{
+				variableId: `broadcast_${item.Id}_description`,
+				name: `Description of broadcast titled '${item.Name}'`,
+			},
 		);
 	});
 
@@ -148,7 +152,7 @@ export function getBroadcastVars(broadcast: Broadcast): VariableContent[] {
 		value: broadcast.Visibility,
 	};
 
-	return [lifecycle, visibility];
+	return [lifecycle, visibility, description];
 }
 
 /**


### PR DESCRIPTION
Adds a per-broadcast Companion variable exposing the cached YouTube description as `broadcast_<ID>_description`.

The module already stores `Description` in the cached `Broadcast` object, so this does not require an additional YouTube API request.

This enables workflows such as checking whether a description already contains a chapter/bookmark section before using the existing `Append text to description` action, avoiding duplicate chapter blocks.

Changes:
- Expose `broadcast_<ID>_description` in `src/vars.ts`
- Export the cached `broadcast.Description` value
- Add tests for variable declaration, presence, and exported description value

Related: #179